### PR TITLE
Add dark mode for Windows OS

### DIFF
--- a/src/darkmode.hpp
+++ b/src/darkmode.hpp
@@ -6,9 +6,9 @@
 #include <QPalette>
 
 void set_darkmode() {
+    QApplication::setStyle("Fusion");
     QSettings settings("HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", QSettings::NativeFormat);
     if(settings.value("AppsUseLightTheme") == 0){
-        QApplication::setStyle("Fusion");
         QPalette darkPalette;
         darkPalette.setColor(QPalette::Window, QColor(53,53,53));
         darkPalette.setColor(QPalette::WindowText, Qt::white);
@@ -24,24 +24,6 @@ void set_darkmode() {
         darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
         darkPalette.setColor(QPalette::HighlightedText, Qt::black);
         qApp->setPalette(darkPalette);
-    }
-    else{
-        QApplication::setStyle("Fusion");
-        QPalette lightPalette;
-        lightPalette.setColor(QPalette::Window, QColor(240,240,240));
-        lightPalette.setColor(QPalette::WindowText, Qt::black);
-        lightPalette.setColor(QPalette::Base, QColor(240,240,240));
-        lightPalette.setColor(QPalette::AlternateBase, QColor(240,240,240));
-        lightPalette.setColor(QPalette::ToolTipBase, Qt::black);
-        lightPalette.setColor(QPalette::ToolTipText, Qt::black);
-        lightPalette.setColor(QPalette::Text, Qt::black);
-        lightPalette.setColor(QPalette::Button, QColor(240,240,240));
-        lightPalette.setColor(QPalette::ButtonText, Qt::black);
-        lightPalette.setColor(QPalette::BrightText, Qt::red);
-        lightPalette.setColor(QPalette::Link, QColor(42, 130, 218));
-        lightPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-        lightPalette.setColor(QPalette::HighlightedText, Qt::white);
-        qApp->setPalette(lightPalette);
     }
 }
 

--- a/src/darkmode.hpp
+++ b/src/darkmode.hpp
@@ -1,0 +1,48 @@
+#ifndef DARKMODE_HPP
+#define DARKMODE_HPP
+
+#include <QApplication>
+#include <QSettings>
+#include <QPalette>
+
+void set_darkmode() {
+    QSettings settings("HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", QSettings::NativeFormat);
+    if(settings.value("AppsUseLightTheme") == 0){
+        QApplication::setStyle("Fusion");
+        QPalette darkPalette;
+        darkPalette.setColor(QPalette::Window, QColor(53,53,53));
+        darkPalette.setColor(QPalette::WindowText, Qt::white);
+        darkPalette.setColor(QPalette::Base, QColor(25,25,25));
+        darkPalette.setColor(QPalette::AlternateBase, QColor(53,53,53));
+        darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
+        darkPalette.setColor(QPalette::ToolTipText, Qt::white);
+        darkPalette.setColor(QPalette::Text, Qt::white);
+        darkPalette.setColor(QPalette::Button, QColor(53,53,53));
+        darkPalette.setColor(QPalette::ButtonText, Qt::white);
+        darkPalette.setColor(QPalette::BrightText, Qt::red);
+        darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
+        darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+        darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+        qApp->setPalette(darkPalette);
+    }
+    else{
+        QApplication::setStyle("Fusion");
+        QPalette lightPalette;
+        lightPalette.setColor(QPalette::Window, QColor(240,240,240));
+        lightPalette.setColor(QPalette::WindowText, Qt::black);
+        lightPalette.setColor(QPalette::Base, QColor(240,240,240));
+        lightPalette.setColor(QPalette::AlternateBase, QColor(240,240,240));
+        lightPalette.setColor(QPalette::ToolTipBase, Qt::black);
+        lightPalette.setColor(QPalette::ToolTipText, Qt::black);
+        lightPalette.setColor(QPalette::Text, Qt::black);
+        lightPalette.setColor(QPalette::Button, QColor(240,240,240));
+        lightPalette.setColor(QPalette::ButtonText, Qt::black);
+        lightPalette.setColor(QPalette::BrightText, Qt::red);
+        lightPalette.setColor(QPalette::Link, QColor(42, 130, 218));
+        lightPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+        lightPalette.setColor(QPalette::HighlightedText, Qt::white);
+        qApp->setPalette(lightPalette);
+    }
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,9 @@
 #include "main_window.hpp"
 #include "settings.hpp"
 #include "system.hpp"
+#ifdef Q_OS_WIN
+    #include "darkmode.hpp"
+#endif
 
 #include <QApplication>
 #include <QMessageBox>
@@ -31,6 +34,11 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
 
     QGuiApplication::setWindowIcon(QIcon(":/resources/obliteration-icon.png"));
+
+    // Set dark/light mode for Windows, Qt already handles MacOS and Linux themes.
+    #ifdef Q_OS_WIN
+        set_darkmode();
+    #endif
 
     // Initialize user settings.
     if (!hasRequiredUserSettings()) {


### PR DESCRIPTION
A placeholder implementation until Qt officially adds automatic theme application for light and dark modes.

Main.cpp checks if it is being built for Windows, and if so, it'll include the DarkMode code, and if not, it doesn't include the DarkMode code. Meant to reduce space for other OSes.

Resolves #22 