### PR TITLE
Moves SELF segment reader out of process module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ Obliteration requires the `PS4UPDATE1.PUP.dec` firmware file in order to work. W
 - Visual Studio 2022
   - `Desktop development with C++` workload is required
   - You need to install the `MSVC v142 - VS 2019 C++ x64/x86 build tools` component
-- Rust 1.63+
+- Rust on latest stable channel
 - CMake 3.21+
   - Make sure you have `Add CMake to the system PATH` selected when installing
 
 ### Linux prerequisites
 
 - GCC 9.4+
-- Rust 1.63+
+- Rust on latest stable channel
 - CMake 3.21+
 
 ### macOS prerequisites
@@ -74,7 +74,7 @@ Obliteration requires the `PS4UPDATE1.PUP.dec` firmware file in order to work. W
 - macOS 12+
 - Homebrew
 - Clang 13+
-- Rust 1.63+
+- Rust on latest stable channel
 - CMake 3.21+
 
 ### Install Qt 6

--- a/src/kernel/src/elf/program.rs
+++ b/src/kernel/src/elf/program.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+#[derive(Clone)]
 pub struct Program {
     ty: ProgramType,
     flags: ProgramFlags,

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -101,7 +101,7 @@ fn run() -> bool {
     // Get eboot.bin.
     info!(0, "Getting /mnt/app0/eboot.bin.");
 
-    let mut eboot = match fs.get("/mnt/app0/eboot.bin") {
+    let eboot = match fs.get("/mnt/app0/eboot.bin") {
         Ok(v) => match v {
             fs::Item::Directory(_) => {
                 error!(0, "Path to eboot.bin is a directory.");
@@ -118,7 +118,7 @@ fn run() -> bool {
     // Load eboot.bin.
     info!(0, "Loading eboot.bin.");
 
-    let elf = match SignedElf::load(&mut eboot) {
+    let elf = match SignedElf::load(eboot) {
         Ok(v) => v,
         Err(e) => {
             error!(0, e, "Load failed");
@@ -158,7 +158,7 @@ fn run() -> bool {
         dump_path: args.debug_dump.join("process"),
     };
 
-    let mut process = match Process::load(elf, eboot, debug) {
+    let mut process = match Process::load(elf, debug) {
         Ok(v) => v,
         Err(e) => {
             error!(0, e, "Create failed");

--- a/src/kernel/src/process/mod.rs
+++ b/src/kernel/src/process/mod.rs
@@ -1,6 +1,5 @@
 use self::module::{Arg, EntryPoint, Module};
 use crate::elf::SignedElf;
-use crate::fs::file::File;
 use crate::info;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -24,11 +23,7 @@ pub struct Process {
 }
 
 impl Process {
-    pub(super) fn load(
-        elf: SignedElf,
-        file: File,
-        debug: DebugOpts,
-    ) -> Result<Pin<Box<Self>>, LoadError> {
+    pub(super) fn load(elf: SignedElf, debug: DebugOpts) -> Result<Pin<Box<Self>>, LoadError> {
         let mut proc = Box::pin(Self {
             id: 1,
             entry: uninit(),
@@ -45,7 +40,7 @@ impl Process {
             original_mapped_dump: debug.dump_path.join("eboot.bin.mapped"),
         };
 
-        match Module::load(&mut *proc, elf, file, debug) {
+        match Module::load(&mut *proc, elf, debug) {
             Ok(v) => {
                 proc.entry = v.entry();
                 proc.modules.push(v);


### PR DESCRIPTION
So we can move `File` into `SignedElf` and don't need to pass both `File` and `SignedElf` to the functions that need both of them.

Also raise the required of Rust to latest stable because usually everyone will install the latest version anyway. It is much easier to write a code that target latest stable instead of the previous version because we don't need to check if the feature we use is supported by the specific version.