### PR TITLE
Update Iced-x86 and clap

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/main.rs"
 
 [dependencies]
 bitflags = "1.3"
-clap = { version = "4.0", features = ["derive"] }
-iced-x86 = { version = "1.17", features = ["code_asm"] }
+clap = { version = "4.1", features = ["derive"] }
+iced-x86 = { version = "1.18", features = ["code_asm"] }
 libc = "0.2"
 linked_list_allocator = { version = "0.10", default-features = false }
 memmap2 = "0.5"


### PR DESCRIPTION
Testing of both Kernel and Qt app showed no regressions. 