### PR TITLE
Changes the first parameter of pfs::open() to Read + Seek

### DIFF
--- a/src/pfs/Cargo.toml
+++ b/src/pfs/Cargo.toml
@@ -9,5 +9,6 @@ flate2 = "1.0"
 generic-array = "0.14"
 hmac = "0.12"
 sha2 = "0.10"
+thiserror = "1.0"
 util = { path = "../util" }
 xts-mode = "0.5"


### PR DESCRIPTION
First step of #98. The reason of this change is because we need to open a PFS that is inside another PFS without extracting it first. Each file in the PFS is implemented `Read` and `Seek`. So it order to achieve this we need to change the input of `pfs::open` to `Read` + `Seek`.

The reason I removed the logging about PFS is because we need to figure out some solutions to get a PFS header from the refactored code. We are going to remove the PFS mounting from the kernel anyway so it is not worth the effort.