### PR TITLE
C++ warning fix

### DIFF
--- a/src/progress_dialog.hpp
+++ b/src/progress_dialog.hpp
@@ -23,7 +23,7 @@ public:
 
 protected:
     void closeEvent(QCloseEvent *event) override;
-    void keyPressEvent(QKeyEvent *event);
+    void keyPressEvent(QKeyEvent *event) override;
 
 private:
     QProgressBar *m_progress;


### PR DESCRIPTION
Super simple fix for annoying C++ warning. One still left but its there for a reason

```
In file included from /Users/wojciechbartnik/h_dev/obliteration/src/game_settings_dialog.cpp:1:
/Users/yisonPylkita/h_dev/obliteration/src/game_settings_dialog.hpp:13:11: warning: private field 'm_game' is not used [-Wunused-private-field]
    Game *m_game;
```

Also, do you guys have a plan do do something about this wall of Rust warnings?
```
warning: associated function `transform_xadd_rm32_r32` is never used
    --> kernel/src/process/module/recompiler.rs:1814:8
     |
1814 |     fn transform_xadd_rm32_r32(&mut self, i: Instruction) -> usize {
     |        ^^^^^^^^^^^^^^^^^^^^^^^

warning: associated function `transform_xchg_rm8_r8` is never used
    --> kernel/src/process/module/recompiler.rs:1824:8
     |
1824 |     fn transform_xchg_rm8_r8(&mut self, i: Instruction) -> usize {
     |        ^^^^^^^^^^^^^^^^^^^^^

warning: associated function `transform_xchg_rm32_r32` is never used
    --> kernel/src/process/module/recompiler.rs:1834:8
     |
1834 |     fn transform_xchg_rm32_r32(&mut self, i: Instruction) -> usize {
     |        ^^^^^^^^^^^^^^^^^^^^^^^

warning: associated function `transform_xor_rm8_r8` is never used
    --> kernel/src/process/module/recompiler.rs:1844:8
     |
1844 |     fn transform_xor_rm8_r8(&mut self, i: Instruction) -> usize {
     |        ^^^^^^^^^^^^^^^^^^^^

warning: associated function `transform_xor_rm32_r32` is never used
    --> kernel/src/process/module/recompiler.rs:1854:8
     |
1854 |     fn transform_xor_rm32_r32(&mut self, i: Instruction) -> usize {
     |        ^^^^^^^^^^^^^^^^^^^^^^

warning: associated function `preserve` is never used
    --> kernel/src/process/module/recompiler.rs:1864:8
     |
1864 |     fn preserve(&mut self, i: Instruction) -> usize {
     |        ^^^^^^^^
```