### PR TITLE
Enables document-mode on main tab

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -75,6 +75,7 @@ MainWindow::MainWindow() :
 
     // Central widget.
     m_tab = new QTabWidget(this);
+    m_tab->setDocumentMode(true);
 
     setCentralWidget(m_tab);
 


### PR DESCRIPTION
According to [documentation](https://doc.qt.io/qt-6/qtabwidget.html#documentMode-prop) it is what we should enabled for the main tab. I hope we will got a good looking on macOS with this too.

Before:
![Screenshot from 2023-02-05 18-05-16](https://user-images.githubusercontent.com/3048307/216826538-1118bdce-fe3b-4f84-96b1-af689db7e6b9.png)

After:
![Screenshot from 2023-02-05 18-04-35](https://user-images.githubusercontent.com/3048307/216826556-b073a278-29ea-427c-a349-786d346f1b0f.png)