### PR TITLE
fix bug in handle_u2 function

### DIFF
--- a/src/kernel/src/process/mod.rs
+++ b/src/kernel/src/process/mod.rs
@@ -91,10 +91,7 @@ impl Process {
 
     #[cfg(not(target_arch = "x86_64"))]
     extern "C" fn handle_ud2(&mut self, addr: usize) -> ! {
-        info!(
-            self.id,
-            "process exited with ud2 instruction from {:#018x}.", addr
-        );
+        info!("process exited with ud2 instruction from {:#018x}.", addr);
 
         // fixme: return to "run" without stack unwinding on windows.
         std::process::exit(0);


### PR DESCRIPTION
an id is incorrectly passed into the non-x86_64 variant of the ```handle_u2``` function.