### PR TITLE
Refactors MemoryManager and fixes munmap bug

### DIFF
--- a/src/kernel/src/memory/iter.rs
+++ b/src/kernel/src/memory/iter.rs
@@ -1,0 +1,88 @@
+use super::Alloc;
+use std::collections::BTreeMap;
+
+/// An iterator to enumerate all [`Alloc`] starting within the specified address.
+pub(super) struct StartFrom<'a> {
+    iter: Option<std::collections::btree_map::Range<'a, usize, Alloc>>,
+}
+
+impl<'a> StartFrom<'a> {
+    pub fn new(map: &'a BTreeMap<usize, Alloc>, addr: usize) -> Self {
+        // Find the first allocation info.
+        let first = match map.range(..=addr).next_back() {
+            Some(v) => v.1,
+            None => return Self { iter: None },
+        };
+
+        // Check if the target address is in the range of first allocation.
+        Self {
+            iter: if (first.end() as usize) <= addr {
+                None
+            } else {
+                Some(map.range((first.addr as usize)..))
+            },
+        }
+    }
+}
+
+impl<'a> Iterator for StartFrom<'a> {
+    type Item = (usize, &'a Alloc);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let iter = match &mut self.iter {
+            Some(v) => v,
+            None => return None,
+        };
+
+        match iter.next() {
+            Some(v) => Some((*v.0, v.1)),
+            None => {
+                self.iter = None;
+                None
+            }
+        }
+    }
+}
+
+/// An iterator to enumerate all [`Alloc`] as mutable starting within the specified address.
+pub(super) struct StartFromMut<'a> {
+    iter: Option<std::collections::btree_map::RangeMut<'a, usize, Alloc>>,
+}
+
+impl<'a> StartFromMut<'a> {
+    pub fn new(map: &'a mut BTreeMap<usize, Alloc>, addr: usize) -> Self {
+        // Find the first allocation info.
+        let first = match map.range(..=addr).next_back() {
+            Some(v) => v.1,
+            None => return Self { iter: None },
+        };
+
+        // Check if the target address is in the range of first allocation.
+        Self {
+            iter: if (first.end() as usize) <= addr {
+                None
+            } else {
+                Some(map.range_mut((first.addr as usize)..))
+            },
+        }
+    }
+}
+
+impl<'a> Iterator for StartFromMut<'a> {
+    type Item = (usize, &'a mut Alloc);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let iter = match &mut self.iter {
+            Some(v) => v,
+            None => return None,
+        };
+
+        match iter.next() {
+            Some(v) => Some((*v.0, v.1)),
+            None => {
+                self.iter = None;
+                None
+            }
+        }
+    }
+}

--- a/src/kernel/src/memory/storage.rs
+++ b/src/kernel/src/memory/storage.rs
@@ -1,0 +1,146 @@
+use super::Protections;
+
+/// Represents a storage for [`super::Alloc`].
+///
+/// Multiple [`super::Alloc`] can share a single storage.
+pub(super) trait Storage {
+    fn addr(&self) -> *mut u8;
+    fn decommit(&self, addr: *mut u8, len: usize) -> Result<(), std::io::Error>;
+}
+
+/// An implementation of [`Storage`] backed by the memory.
+pub(super) struct Memory {
+    addr: *mut u8,
+    len: usize,
+}
+
+impl Memory {
+    #[cfg(unix)]
+    pub fn new(len: usize) -> Result<Self, std::io::Error> {
+        use libc::{mmap, MAP_ANON, MAP_FAILED, MAP_PRIVATE, PROT_NONE};
+        use std::ptr::null_mut;
+
+        let addr = unsafe { mmap(null_mut(), len, PROT_NONE, MAP_PRIVATE | MAP_ANON, -1, 0) };
+
+        if addr == MAP_FAILED {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            addr: addr as _,
+            len,
+        })
+    }
+
+    #[cfg(windows)]
+    pub fn new(len: usize) -> Result<Self, std::io::Error> {
+        use std::ptr::null;
+        use windows_sys::Win32::System::Memory::{VirtualAlloc, MEM_RESERVE, PAGE_NOACCESS};
+
+        let addr = unsafe { VirtualAlloc(null(), len, MEM_RESERVE, PAGE_NOACCESS) };
+
+        if addr.is_null() {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            addr: addr as _,
+            len,
+        })
+    }
+
+    #[cfg(unix)]
+    pub fn commit(
+        &self,
+        addr: *const u8,
+        len: usize,
+        prot: Protections,
+    ) -> Result<(), std::io::Error> {
+        use libc::{mmap, MAP_ANON, MAP_FAILED, MAP_FIXED, MAP_PRIVATE};
+
+        let ptr = unsafe {
+            mmap(
+                addr as _,
+                len,
+                prot.into_host(),
+                MAP_PRIVATE | MAP_ANON | MAP_FIXED,
+                -1,
+                0,
+            )
+        };
+
+        if ptr == MAP_FAILED {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn commit(
+        &self,
+        addr: *const u8,
+        len: usize,
+        prot: Protections,
+    ) -> Result<(), std::io::Error> {
+        use windows_sys::Win32::System::Memory::{VirtualAlloc, MEM_COMMIT};
+
+        let ptr = unsafe { VirtualAlloc(addr as _, len, MEM_COMMIT, prot.into_host()) };
+
+        if ptr.is_null() {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Storage for Memory {
+    fn addr(&self) -> *mut u8 {
+        self.addr
+    }
+
+    #[cfg(unix)]
+    fn decommit(&self, addr: *mut u8, len: usize) -> Result<(), std::io::Error> {
+        use libc::{mprotect, PROT_NONE};
+
+        if unsafe { mprotect(addr as _, len, PROT_NONE) } < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(windows)]
+    fn decommit(&self, addr: *mut u8, len: usize) -> Result<(), std::io::Error> {
+        use windows_sys::Win32::System::Memory::{VirtualFree, MEM_DECOMMIT};
+
+        if unsafe { VirtualFree(addr as _, len, MEM_DECOMMIT) } == 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for Memory {
+    #[cfg(unix)]
+    fn drop(&mut self) {
+        use libc::munmap;
+
+        if unsafe { munmap(self.addr as _, self.len) } < 0 {
+            let e = std::io::Error::last_os_error();
+            panic!("Failed to unmap {:p}:{}: {}.", self.addr, self.len, e);
+        }
+    }
+
+    #[cfg(windows)]
+    fn drop(&mut self) {
+        use windows_sys::Win32::System::Memory::{VirtualFree, MEM_RELEASE};
+
+        if unsafe { VirtualFree(self.addr as _, 0, MEM_RELEASE) } == 0 {
+            let e = std::io::Error::last_os_error();
+            panic!("Failed to free {:p}: {}.", self.addr, e);
+        }
+    }
+}


### PR DESCRIPTION
This refactor is a preparation for `mprotect` and for supporting file-mapped. This also fix `munmap` bug when `addr` is not the starting address of the first allocation.