### PR TITLE
Fix Clippy implementation in QC

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -34,6 +34,3 @@ jobs:
       run: cmake --preset mac-release .
     - name: Build
       run: cmake --build --preset mac-release
-    - name: Run Clippy
-      run: cargo clippy --release
-      working-directory: src

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -47,9 +47,6 @@ jobs:
       run: cmake --preset windows-release .
     - name: Build
       run: cmake --build --preset windows-release
-    - name: Run Clippy
-      run: cargo clippy --release
-      working-directory: src
     - name: Export artifacts
       run: cmake --install build --prefix dist
     - name: Upload artifacts

--- a/.github/workflows/qc-prebuild.yml
+++ b/.github/workflows/qc-prebuild.yml
@@ -2,11 +2,17 @@ name: Prebuild Quality Checks
 on:
   workflow_call:
 jobs:
-  code-checks:
-    name: Code Checks
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Checkout source
-      uses: actions/checkout@v3
-    - name: Run RustFMT Check
-      run: cd src && cargo fmt --check
+    code-checks:
+        name: Code Checks (RustFMT and Clippy)
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [windows-2019, macos-12, ubuntu-22.04]
+        steps:
+        - name: Checkout source
+          uses: actions/checkout@v3
+        - name: Run RustFMT Check
+          run: cd src && cargo fmt --check
+        - if: ${{ matrix.os != 'ubuntu-22.04' }}
+          name: Run Rust-Clippy Check
+          run: cd src && cargo clippy


### PR DESCRIPTION
This makes it so that Clippy runs on all OSes except ubuntu, while keeping it in the QC yml.