### PR TITLE
Fix build issue for arm macs

### DIFF
--- a/src/kernel-macros/src/cpu_abi.rs
+++ b/src/kernel-macros/src/cpu_abi.rs
@@ -21,7 +21,7 @@ pub fn transform(item: ItemFn) -> syn::Result<TokenStream> {
     #[cfg(target_arch = "x86_64")]
     let abi = "sysv64";
     #[cfg(target_arch = "aarch64")]
-    let abi = "aapcs";
+    let abi = "C";
     let attrs = item.attrs;
     let vis = item.vis;
     let safety = item.sig.unsafety;

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -216,7 +216,10 @@ fn main() -> ExitCode {
         }
         #[cfg(not(target_arch = "x86_64"))]
         ExecutionEngine::Native => {
-            error!("Native execution engine cannot be used on your machine.");
+            error!(
+                logger,
+                "Native execution engine cannot be used on your machine."
+            );
             return ExitCode::FAILURE;
         }
         ExecutionEngine::Llvm => {


### PR DESCRIPTION
This PR fixes building on arm macs by switching to the ```extern "C"``` abi and fixing an erroneous macro input for the error macro. Closes #260  