### PR TITLE
Fix issue with Obliteration giving an exception when trying to use KillKernel while the kernel has crashed.

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -494,14 +494,17 @@ bool MainWindow::loadGame(const QString &gameId)
 
 void MainWindow::killKernel()
 {
-    // We need to disconnect all slots first otherwise the application will be freezing.
-    disconnect(m_kernel, nullptr, nullptr, nullptr);
+    // Make sure Kernel is a process before attempting to kill. (Prevents 0xc0000005 exception)
+    if(m_kernel != nullptr) {
+        // We need to disconnect all slots first otherwise the application will freeze.
+        disconnect(m_kernel, nullptr, nullptr, nullptr);
 
-    m_kernel->kill();
-    m_kernel->waitForFinished(-1);
+        m_kernel->kill();
+        m_kernel->waitForFinished(-1);
 
-    delete m_kernel;
-    m_kernel = nullptr;
+        delete m_kernel;
+        m_kernel = nullptr;
+    }
 }
 
 void MainWindow::restoreGeometry()


### PR DESCRIPTION
Fixes #229

A simple change that makes Qt check if the Kernel is a present process in the system before attempting to kill the kernel. This prevents the 0xc0000005 exception that would occur if Qt tried to kill the kernel after it crashed.