### PR TITLE
Added ability to open game folder.

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -318,9 +318,11 @@ void MainWindow::requestGamesContextMenu(const QPoint &pos)
 
     // Setup menu.
     QMenu menu(this);
-    QAction settings("&Settings", this);
+    QAction settings("&Settings", this); // TODO LATER: Blank Settings
+    QAction openFolder("Open Game &Folder", this); // Opens game folder.
 
     menu.addAction(&settings);
+    menu.addAction(&openFolder);
 
     // Show menu.
     auto selected = menu.exec(m_games->viewport()->mapToGlobal(pos));
@@ -332,6 +334,9 @@ void MainWindow::requestGamesContextMenu(const QPoint &pos)
     if (selected == &settings) {
         GameSettingsDialog dialog(game, this);
         dialog.exec();
+    } else if (selected == &openFolder) {
+        QString folderPath = game->directory();
+        QDesktopServices::openUrl(QUrl::fromLocalFile(folderPath));
     }
 }
 


### PR DESCRIPTION
One of my game dumps on my PS4 were faulty and it was a pain to figure out which folder it was in Obliteration's game directory that was the incomplete install. Afterwards, I got the simple idea: "Why not add the ability to open the game folder by right clicking on the game?"