### PR TITLE
Fix wrong parameter in error macro for non-x64

### DIFF
--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -252,7 +252,6 @@ fn main() -> ExitCode {
         #[cfg(not(target_arch = "x86_64"))]
         ExecutionEngine::Native => {
             error!(
-                logger,
                 "Native execution engine cannot be used on your machine."
             );
             return ExitCode::FAILURE;

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -251,9 +251,7 @@ fn main() -> ExitCode {
         }
         #[cfg(not(target_arch = "x86_64"))]
         ExecutionEngine::Native => {
-            error!(
-                "Native execution engine cannot be used on your machine."
-            );
+            error!("Native execution engine cannot be used on your machine.");
             return ExitCode::FAILURE;
         }
         ExecutionEngine::Llvm => {


### PR DESCRIPTION
We should really look into getting github actions for m1 macs these type of issues are hard to catch due to conditional compilation. 