### PR TITLE
Implement Rich Presence

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 bitflags = "2.1"
 byteorder = "1.4"
 clap = { version = "4.1", features = ["derive"] }
+discord-rich-presence = "0.2.3"
 elf = { path = "../elf" }
 gmtx = { path = "../gmtx" }
 iced-x86 = { version = "1.18", features = ["code_asm"] }

--- a/src/kernel/src/discord_presence/mod.rs
+++ b/src/kernel/src/discord_presence/mod.rs
@@ -10,13 +10,13 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
     let mut client = match DiscordIpcClient::new("1168617561244565584") {
         Ok(client) => client,
         Err(e) => {
-            warn!("Failed to create Discord IPC: {:?}", e);
+            warn!(e, "Failed to create Discord IPC");
             return Err(e.into());
         }
     };
 
     if let Err(e) = client.connect() {
-        warn!("Failed to connect to Discord client: {:?}", e);
+        warn!(e, "Failed to connect to Discord client");
         return Err(e.into());
     }
 
@@ -25,7 +25,8 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
         .as_secs()
         .try_into()
         .unwrap();
-    let param_path = game_path.join("sce_sys/param.sfo");
+    let mut param_path = game_path.join("sce_sys");
+    param_path.push("param.sfo");
     let mut title = String::from("Unknown Title");
     let mut title_id = String::from("Unknown Title ID");
 
@@ -35,9 +36,9 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
                 title = param.title().to_string();
                 title_id = param.title_id().to_string();
             }
-            Err(e) => warn!("Failed to read param.sfo, using placeholders: {:?}", e),
+            Err(e) => warn!(e, "Failed to read param.sfo, using placeholders"),
         },
-        Err(e) => warn!("Failed to open param.sfo, using placeholders: {:?}", e),
+        Err(e) => warn!(e, "Failed to open param.sfo, using placeholders"),
     }
 
     let details_text = &format!("Playing {} - {}", title, title_id);
@@ -50,7 +51,7 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
         )
         .timestamps(activity::Timestamps::new().start(start_time));
     if let Err(e) = client.set_activity(payload) {
-        warn!("Failed to update Discord presence: {:?}", e);
+        warn!(e, "Failed to update Discord presence");
         return Err(e.into());
     }
     Ok(client)

--- a/src/kernel/src/discord_presence/mod.rs
+++ b/src/kernel/src/discord_presence/mod.rs
@@ -1,0 +1,57 @@
+use crate::{info, warn};
+use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+use param::Param;
+use std::fs::File;
+use std::path::Path;
+use std::time::SystemTime;
+
+pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::error::Error>> {
+    info!("Initializing Discord rich presence.");
+    let mut client = match DiscordIpcClient::new("1168617561244565584") {
+        Ok(client) => client,
+        Err(e) => {
+            warn!("Failed to create Discord IPC: {:?}", e);
+            return Err(e.into());
+        }
+    };
+
+    if let Err(e) = client.connect() {
+        warn!("Failed to connect to Discord client: {:?}", e);
+        return Err(e.into());
+    }
+
+    let start_time: i64 = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_secs()
+        .try_into()
+        .unwrap();
+    let param_path = game_path.join("sce_sys/param.sfo");
+    let mut title = String::from("Unknown Title");
+    let mut title_id = String::from("Unknown Title ID");
+
+    match File::open(&param_path) {
+        Ok(param_file) => match Param::read(param_file) {
+            Ok(param) => {
+                title = param.title().to_string();
+                title_id = param.title_id().to_string();
+            }
+            Err(e) => warn!("Failed to read param.sfo, using placeholders: {:?}", e),
+        },
+        Err(e) => warn!("Failed to open param.sfo, using placeholders: {:?}", e),
+    }
+
+    let details_text = &format!("Playing {} - {}", title, title_id);
+    let payload = activity::Activity::new()
+        .details(details_text)
+        .assets(
+            activity::Assets::new()
+                .large_image("obliteration-icon")
+                .large_text("Obliteration"),
+        )
+        .timestamps(activity::Timestamps::new().start(start_time));
+    if let Err(e) = client.set_activity(payload) {
+        warn!("Failed to update Discord presence: {:?}", e);
+        return Err(e.into());
+    }
+    Ok(client)
+}

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -92,10 +92,8 @@ fn main() -> ExitCode {
     }
 
     // Begin Discord Rich Presence after successful basic init.
-    let game_display = args.game.display().to_string();
-    let game_path = std::path::Path::new(&game_display);
     // Keep client active by storing in variable.
-    let _client = discord_presence::rich_presence(&game_path);
+    let _client = discord_presence::rich_presence(&args.game.clone());
 
     // Show basic infomation.
     let mut log = info!();

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -25,6 +25,7 @@ mod arch;
 mod arnd;
 mod budget;
 mod console;
+mod discord_presence;
 mod ee;
 mod errno;
 mod fs;
@@ -41,6 +42,7 @@ mod sysctl;
 mod ucred;
 
 fn main() -> ExitCode {
+    // Begin logger
     log::init();
 
     // Load arguments.
@@ -88,6 +90,12 @@ fn main() -> ExitCode {
             Err(e) => warn!(e, "Failed to create {}", log.display()),
         }
     }
+
+    // Begin Discord Rich Presence after successful basic init.
+    let game_display = args.game.display().to_string();
+    let game_path = std::path::Path::new(&game_display);
+    // Keep client active by storing in variable.
+    let _client = discord_presence::rich_presence(&game_path);
 
     // Show basic infomation.
     let mut log = info!();


### PR DESCRIPTION
![image](https://github.com/obhq/obliteration/assets/45863583/b2b7278a-3d8c-4587-aee6-d59a33e05de3)

Implements Discord Rich Presence into the kernel.

I used an artificial 65 second sleep on syscall 487 to showcase the Presence working on the image above.
The presence grabs the Title and TitleID from the Param.sfo file of the game, along with showing how long the game has been running.

Completes #420 