### PR TITLE
xsave64 alignment fix

### DIFF
--- a/src/kernel/src/ee/native/mod.rs
+++ b/src/kernel/src/ee/native/mod.rs
@@ -521,7 +521,7 @@ impl NativeEngine {
         asm.add(rbx, 14 * 8).unwrap(); // Output placeholder.
 
         // Save x87, SSE and AVX states.
-        let xsave = (self.xsave_area + 15) & !15;
+        let xsave = (self.xsave_area + 63) & !63;
 
         asm.sub(rsp, xsave).unwrap();
         asm.mov(ecx, xsave).unwrap();


### PR DESCRIPTION
Fixes #419 for me and the other commenter on the issue who suggested the fix.

And also, the Intel developer manual does actually state that the address should be 64-byte aligned.