### PR TITLE
Adds comments to Discord mod.rs, along with displaying Param information.

### DIFF
--- a/src/kernel/src/discord_presence/mod.rs
+++ b/src/kernel/src/discord_presence/mod.rs
@@ -1,30 +1,14 @@
+use crate::log::print;
 use crate::{info, warn};
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use param::Param;
 use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 use std::time::SystemTime;
 
 pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::error::Error>> {
-    info!("Initializing Discord rich presence.");
-    let mut client = match DiscordIpcClient::new("1168617561244565584") {
-        Ok(client) => client,
-        Err(e) => {
-            warn!(e, "Failed to create Discord IPC");
-            return Err(e.into());
-        }
-    };
-
-    if let Err(e) = client.connect() {
-        warn!(e, "Failed to connect to Discord client");
-        return Err(e.into());
-    }
-
-    let start_time: i64 = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)?
-        .as_secs()
-        .try_into()
-        .unwrap();
+    // Fetch Title and TitleID from Param.sfo if possible
     let mut param_path = game_path.join("sce_sys");
     param_path.push("param.sfo");
     let mut title = String::from("Unknown Title");
@@ -41,6 +25,38 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
         Err(e) => warn!(e, "Failed to open param.sfo, using placeholders"),
     }
 
+    // Print out Param information for easier reporting.
+    let mut initstatus = info!();
+
+    writeln!(initstatus, "Initializing Discord rich presence.").unwrap();
+    writeln!(initstatus, "Application Title  : {}", title).unwrap();
+    writeln!(initstatus, "Application TitleID: {}", title_id).unwrap();
+
+    print(initstatus);
+
+    // Initialize new Discord IPC with our ID, should never fail.
+    let mut client = match DiscordIpcClient::new("1168617561244565584") {
+        Ok(client) => client,
+        Err(e) => {
+            warn!(e, "Failed to create Discord IPC");
+            return Err(e.into());
+        }
+    };
+
+    // Attempt to have IPC connect to user's Discord, will fail if user doesn't have Discord running.
+    if let Err(e) = client.connect() {
+        warn!(e, "Failed to connect to Discord client");
+        return Err(e.into());
+    }
+
+    // Get Timestamp of Kernel starting for Discord's "elapsed" counter.
+    let start_time: i64 = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_secs()
+        .try_into()
+        .unwrap();
+
+    // Create details about game and send activity to Discord.
     let details_text = &format!("Playing {} - {}", title, title_id);
     let payload = activity::Activity::new()
         .details(details_text)
@@ -50,6 +66,8 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
                 .large_text("Obliteration"),
         )
         .timestamps(activity::Timestamps::new().start(start_time));
+
+    // If failing here, user's Discord most likely crashed or is offline.
     if let Err(e) = client.set_activity(payload) {
         warn!(e, "Failed to update Discord presence");
         return Err(e.into());


### PR DESCRIPTION
Added additional comments to explain what should happen in Discord, along with this, to help users find information about the application they are running, the Discord mod.rs will also display the param.sfo title and titleID to make it simpler to view instead of searching through the log file. Along with this, it allows us to easily find the name of the game used in logs.

With Discord running:

```
++++++++++++++++++ I [00:00:00:00:008]:0x000000000000619c:kernel\src\discord_presence\mod.rs:29
Initializing Discord rich presence.
Application Title  : Amplitude
Application TitleID: CUSA02480
```

With Discord stopped:

```
++++++++++++++++++ I [00:00:00:00:001]:0x0000000000007bdc:kernel\src\discord_presence\mod.rs:29
Initializing Discord rich presence.
Application Title  : OpenOrbis Graphics Sample
Application TitleID: BREW00082
++++++++++++++++++ W [00:00:00:00:001]:0x0000000000007bdc:kernel\src\discord_presence\mod.rs:48
Failed to connect to Discord client: Couldn't connect to the Discord IPC socket.
```