### PR TITLE
implement syscall 605

### DIFF
--- a/src/kernel/src/regmgr/key.rs
+++ b/src/kernel/src/regmgr/key.rs
@@ -17,7 +17,12 @@ impl RegKey {
     pub const AUDIOOUT_CONNECTOR_TYPE: Self = Self(0x0B060000);
     pub const AUDIOOUT_CODEC: Self = Self(0x0B070000);
     pub const NET_WIFI_FREQ_BAND: Self = Self(0x141E0500);
+    pub const NP_DEBUG: Self = Self(0x19810000);
+    pub const BROWSER_DEBUG_NOTIFICATION: Self = Self(0x3CC80700);
     pub const DEVENV_TOOL_BOOT_PARAM: Self = Self(0x78020300);
+    pub const DEVENV_TOOL_TRC_NOTIFY: Self = Self(0x78026400);
+    pub const DEVENT_TOOL_USE_DEFAULT_LIB: Self = Self(0x78028300);
+    pub const DEVENV_TOOL_SYS_PRX_PRELOAD: Self = Self(0x78028A00);
     pub const DEVENV_TOOL_GAME_INTMEM_DBG: Self = Self(0x7802BF00);
 
     pub(super) const fn new(v: u32) -> Self {

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -316,7 +316,7 @@ impl RegMgr {
             let arg: usize = i.args[0].into();
             let key: u32 = arg.try_into().unwrap();
 
-            RegKey::new(key);
+            RegKey::new(key)
         };
 
         match key {

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -312,9 +312,12 @@ impl RegMgr {
     }
 
     fn sys_workaround8849(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
-        let key: usize = i.args[0].into();
-        let key: u32 = key.try_into().unwrap();
-        let key = RegKey::new(key);
+        let key = {
+            let arg: usize = i.args[0].into();
+            let key: u32 = arg.try_into().unwrap();
+
+            RegKey::new(key);
+        };
 
         match key {
             RegKey::NP_DEBUG

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -316,8 +316,11 @@ impl RegMgr {
         let key: u32 = key.try_into().unwrap();
 
         match key {
-            //TODO: figure out what these are
-            1019741952 | 2013432320 | 2013422592 | 2013430528 | 427884544 => {
+            RegKey::NP_DEBUG |
+            RegKey::BROWSER_DEBUG_NOTIFICATION |
+            RegKey::DEVENV_TOOL_TRC_NOTIFY |
+            RegKey::DEVENT_TOOL_USE_DEFAULT_LIB |
+            RegKey::DEVENV_TOOL_SYS_PRX_PRELOAD => {
                 let val = self.get_int(RegKey::new(key)).unwrap();
 
                 Ok(val.into())

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -322,7 +322,7 @@ impl RegMgr {
 
                 Ok(val.into())
             }
-            _ => Err(SysErr::Raw(EINVAL))
+            _ => Err(SysErr::Raw(EINVAL)),
         }
     }
 }

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -158,7 +158,7 @@ impl RegMgr {
 
     /// See `sceRegMgrGetInt` on the PS4 for a reference.
     fn get_int(&self, key: RegKey, out: &mut i32) -> Result<i32, RegError> {
-        let mut buf = [0u8; 4];;
+        let mut buf = [0u8; 4];
 
         if let Err(e) = self.check_param(key, 0, buf.len()) {
             todo!("sceRegMgrGetInt with regMgrComCheckParam({key}, 0, 4) = Err({e})");
@@ -168,7 +168,7 @@ impl RegMgr {
             Ok(v) => {
                 *out = i32::from_le_bytes(buf);
                 Ok(v)
-            },
+            }
             Err(e) => todo!("sceRegMgrGetInt({key}) with regMgrComSetReg() = {e}"),
         }
     }

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -6,6 +6,7 @@ use crate::syscalls::{SysErr, SysIn, SysOut, Syscalls};
 use crate::ucred::Ucred;
 use crate::{info, warn};
 use std::fmt::{Display, Formatter};
+use std::num::NonZeroI32;
 use std::ptr::read;
 use std::sync::Arc;
 use thiserror::Error;
@@ -164,7 +165,7 @@ impl RegMgr {
             todo!("sceRegMgrGetInt with regMgrComCheckParam({key}, 0, 4) = Err({e})");
         }
 
-        match self.get_value(key, &mut buf)? {
+        match self.get_value(key, &mut buf) {
             Ok(v) => {
                 *out = i32::from_le_bytes(buf);
                 Ok(v)
@@ -334,12 +335,12 @@ impl RegMgr {
             | RegKey::DEVENT_TOOL_USE_DEFAULT_LIB
             | RegKey::DEVENV_TOOL_SYS_PRX_PRELOAD => {
                 let mut out = 0;
-                let ret = self.get_int(key, &mut out)?;
+                let ret = self.get_int(key, &mut out).unwrap();
 
                 if ret == 0 {
-                    Ok(val.into())
+                    Ok(out.into())
                 } else {
-                    Err(SysErr::Raw(ret))
+                    Err(SysErr::Raw(unsafe { NonZeroI32::new_unchecked(ret)} ))
                 }
             }
             _ => Err(SysErr::Raw(EINVAL)),

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -340,7 +340,7 @@ impl RegMgr {
                 if ret == 0 {
                     Ok(out.into())
                 } else {
-                    Err(SysErr::Raw(unsafe { NonZeroI32::new_unchecked(ret)} ))
+                    Err(SysErr::Raw(unsafe { NonZeroI32::new_unchecked(ret) }))
                 }
             }
             _ => Err(SysErr::Raw(EINVAL)),

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -314,14 +314,15 @@ impl RegMgr {
     fn sys_workaround8849(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
         let key: usize = i.args[0].into();
         let key: u32 = key.try_into().unwrap();
+        let key = RegKey::new(key);
 
         match key {
-            RegKey::NP_DEBUG |
-            RegKey::BROWSER_DEBUG_NOTIFICATION |
-            RegKey::DEVENV_TOOL_TRC_NOTIFY |
-            RegKey::DEVENT_TOOL_USE_DEFAULT_LIB |
-            RegKey::DEVENV_TOOL_SYS_PRX_PRELOAD => {
-                let val = self.get_int(RegKey::new(key)).unwrap();
+            RegKey::NP_DEBUG
+            | RegKey::BROWSER_DEBUG_NOTIFICATION
+            | RegKey::DEVENV_TOOL_TRC_NOTIFY
+            | RegKey::DEVENT_TOOL_USE_DEFAULT_LIB
+            | RegKey::DEVENV_TOOL_SYS_PRX_PRELOAD => {
+                let val = self.get_int(key).unwrap();
 
                 Ok(val.into())
             }


### PR DESCRIPTION
Should fix #415 once syscall 596 is implemented.
I'm not sure about the unwrap after get_int.