### PR TITLE
General additions + Implementations

### DIFF
--- a/src/elf/src/symbol.rs
+++ b/src/elf/src/symbol.rs
@@ -74,7 +74,7 @@ impl Symbol {
     /// Symbol gives the name of the source file associated with the object file.
     pub const STT_FILE: u8 = 4;
 
-    /// Symbol lavels an uninitialized common block (Treated same as STT_OBJECT)
+    /// Symbol labels an uninitialized common block (Treated same as STT_OBJECT)
     pub const STT_COMMON: u8 = 5;
 
     /// Thread local data object.

--- a/src/kernel/src/console/mod.rs
+++ b/src/kernel/src/console/mod.rs
@@ -20,11 +20,11 @@ impl Console {
 impl VFileOps for Console {
     fn ioctl(
         &self,
-        file: &VFile,
-        com: u64,
-        data: &[u8],
-        cred: &Ucred,
-        td: &VThread,
+        _file: &VFile,
+        _com: u64,
+        _data: &[u8],
+        _cred: &Ucred,
+        _td: &VThread,
     ) -> Result<(), Box<dyn Errno>> {
         // TODO: Implement this.
         Ok(())

--- a/src/kernel/src/discord_presence/mod.rs
+++ b/src/kernel/src/discord_presence/mod.rs
@@ -39,14 +39,14 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
         Ok(client) => client,
         Err(e) => {
             warn!(e, "Failed to create Discord IPC");
-            return Err(e.into());
+            return Err(e);
         }
     };
 
     // Attempt to have IPC connect to user's Discord, will fail if user doesn't have Discord running.
     if let Err(e) = client.connect() {
         warn!(e, "Failed to connect to Discord client");
-        return Err(e.into());
+        return Err(e);
     }
 
     // Get Timestamp of Kernel starting for Discord's "elapsed" counter.
@@ -70,7 +70,7 @@ pub fn rich_presence(game_path: &Path) -> Result<DiscordIpcClient, Box<dyn std::
     // If failing here, user's Discord most likely crashed or is offline.
     if let Err(e) = client.set_activity(payload) {
         warn!(e, "Failed to update Discord presence");
-        return Err(e.into());
+        return Err(e);
     }
     Ok(client)
 }

--- a/src/kernel/src/ee/llvm/mod.rs
+++ b/src/kernel/src/ee/llvm/mod.rs
@@ -58,18 +58,18 @@ impl ExecutionEngine for LlvmEngine {
     type SetupModuleErr = SetupModuleError;
     type GetFunctionErr = GetFunctionError;
 
-    fn set_syscalls(&self, _v: Syscalls) {
+    fn set_syscalls(&self, v: Syscalls) {
         todo!()
     }
 
-    fn setup_module(self: &Arc<Self>, _md: &mut Module<Self>) -> Result<(), Self::SetupModuleErr> {
+    fn setup_module(self: &Arc<Self>, md: &mut Module<Self>) -> Result<(), Self::SetupModuleErr> {
         todo!()
     }
 
     unsafe fn get_function(
         self: &Arc<Self>,
-        _md: &Arc<Module<Self>>,
-        _addr: usize,
+        md: &Arc<Module<Self>>,
+        addr: usize,
     ) -> Result<Arc<Self::RawFn>, Self::GetFunctionErr> {
         todo!()
     }
@@ -83,7 +83,7 @@ impl super::RawFn for RawFn {
         todo!()
     }
 
-    unsafe fn exec1<R, A>(&self, _a: A) -> R {
+    unsafe fn exec1<R, A>(&self, a: A) -> R {
         todo!()
     }
 }

--- a/src/kernel/src/ee/llvm/mod.rs
+++ b/src/kernel/src/ee/llvm/mod.rs
@@ -58,18 +58,18 @@ impl ExecutionEngine for LlvmEngine {
     type SetupModuleErr = SetupModuleError;
     type GetFunctionErr = GetFunctionError;
 
-    fn set_syscalls(&self, v: Syscalls) {
+    fn set_syscalls(&self, _v: Syscalls) {
         todo!()
     }
 
-    fn setup_module(self: &Arc<Self>, md: &mut Module<Self>) -> Result<(), Self::SetupModuleErr> {
+    fn setup_module(self: &Arc<Self>, _md: &mut Module<Self>) -> Result<(), Self::SetupModuleErr> {
         todo!()
     }
 
     unsafe fn get_function(
         self: &Arc<Self>,
-        md: &Arc<Module<Self>>,
-        addr: usize,
+        _md: &Arc<Module<Self>>,
+        _addr: usize,
     ) -> Result<Arc<Self::RawFn>, Self::GetFunctionErr> {
         todo!()
     }
@@ -83,7 +83,7 @@ impl super::RawFn for RawFn {
         todo!()
     }
 
-    unsafe fn exec1<R, A>(&self, a: A) -> R {
+    unsafe fn exec1<R, A>(&self, _a: A) -> R {
         todo!()
     }
 }

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -4,7 +4,7 @@ use crate::process::VThread;
 use crate::ucred::Ucred;
 use bitflags::bitflags;
 use std::fmt::{Debug, Display, Formatter};
-use std::ops::Deref;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -26,7 +26,7 @@ impl VFile {
     }
 
     pub fn ops(&self) -> Option<&dyn VFileOps> {
-        self.ops.as_ref().map(|o| o.deref())
+        self.ops.as_deref()
     }
 
     pub fn set_ops(&mut self, v: Option<Box<dyn VFileOps>>) {

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -135,7 +135,7 @@ impl Fs {
         VFile::new(self)
     }
 
-    pub fn revoke<P: Into<VPathBuf>>(&self, path: P) {
+    pub fn revoke<P: Into<VPathBuf>>(&self, _path: P) {
         // TODO: Implement this.
     }
 
@@ -192,7 +192,7 @@ impl Fs {
 
         let fd: i32 = i.args[0].try_into().unwrap();
         let mut com: u64 = i.args[1].into();
-        let data: *const u8 = i.args[2].into();
+        let _data: *const u8 = i.args[2].into();
 
         if com > 0xffffffff {
             com &= 0xffffffff;

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -330,9 +330,19 @@ struct Args {
     execution_engine: Option<ExecutionEngine>,
 }
 
-#[derive(Clone, ValueEnum, Deserialize, Default)]
+#[derive(Clone, ValueEnum, Deserialize)]
 enum ExecutionEngine {
-    #[default]
     Native,
     Llvm,
+}
+
+impl Default for ExecutionEngine {
+    #[cfg(target_arch = "x86_64")]
+    fn default() -> Self {
+        ExecutionEngine::Native
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    fn default() -> Self {
+        ExecutionEngine::Llvm
+    }
 }

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> ExitCode {
 
     // Begin Discord Rich Presence after successful basic init.
     // Keep client active by storing in variable.
-    let _client = discord_presence::rich_presence(&args.game.clone());
+    let _client = discord_presence::rich_presence(&args.game);
 
     // Show basic infomation.
     let mut log = info!();
@@ -330,20 +330,9 @@ struct Args {
     execution_engine: Option<ExecutionEngine>,
 }
 
-#[derive(Clone, ValueEnum, Deserialize)]
+#[derive(Clone, ValueEnum, Deserialize, Default)]
 enum ExecutionEngine {
+    #[default]
     Native,
     Llvm,
-}
-
-impl Default for ExecutionEngine {
-    #[cfg(target_arch = "x86_64")]
-    fn default() -> Self {
-        ExecutionEngine::Native
-    }
-
-    #[cfg(not(target_arch = "x86_64"))]
-    fn default() -> Self {
-        ExecutionEngine::Llvm
-    }
 }

--- a/src/kernel/src/memory/storage.rs
+++ b/src/kernel/src/memory/storage.rs
@@ -59,10 +59,10 @@ impl Memory {
         if ptr.is_null() {
             Err(Error::last_os_error())
         } else {
-            return Ok(Self {
+            Ok(Self {
                 addr: ptr as _,
                 len,
-            });
+            })
         }
     }
 

--- a/src/kernel/src/process/mod.rs
+++ b/src/kernel/src/process/mod.rs
@@ -243,7 +243,7 @@ impl VProc {
         // function succees.
         let vt = VThread::current();
         let mut mask = vt.sigmask_mut();
-        let prev = mask.clone();
+        let prev = *mask;
 
         // Update the mask.
         if let Some(mut set) = set {
@@ -410,8 +410,8 @@ impl VProc {
         } else if lwpid != 0 && lwpid != td.id().get() {
             return Err(SysErr::Raw(ESRCH));
         } else if function == RTP_LOOKUP {
-            (*rtp).ty = td.pri_class();
-            (*rtp).prio = match td.pri_class() & 0xfff7 {
+            rtp.ty = td.pri_class();
+            rtp.prio = match td.pri_class() & 0xfff7 {
                 2 | 3 | 4 => td.base_user_pri(),
                 _ => 0,
             };

--- a/src/kernel/src/regmgr/key.rs
+++ b/src/kernel/src/regmgr/key.rs
@@ -5,8 +5,18 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegKey(u32);
 
+#[allow(dead_code)] // Removes complaints about unused Regkeys.
 impl RegKey {
+    // pub const REGISTRY_VERSION: Self = Self(0);
+    pub const REGISTRY_VERSION: Self = Self(0x01010000);
+    pub const REGISTRY_INSTALL: Self = Self(0x01020000);
+    pub const REGISTRY_UPDATE: Self = Self(0x01030000);
+    pub const REGISTRY_NOT_SAVE: Self = Self(0x01040000);
     pub const REGISTRY_RECOVER: Self = Self(0x01050000);
+    pub const REGISTRY_DOWNGRADE: Self = Self(0x01060000);
+    pub const REGISTRY_BOOTCOUNT: Self = Self(0x01070000);
+    pub const REGISTRY_LASTVER: Self = Self(0x01080000);
+    pub const REGISTRY_INIT_FLAG: Self = Self(0x01400000);
     pub const SYSTEM_UPDATE_MODE: Self = Self(0x02010000);
     pub const SYSTEM_POWER_SHUTDOWN_STATUS: Self = Self(0x02820E00);
     pub const SYSTEM_SPECIFIC_IDU_MODE: Self = Self(0x02860100);
@@ -21,7 +31,7 @@ impl RegKey {
     pub const BROWSER_DEBUG_NOTIFICATION: Self = Self(0x3CC80700);
     pub const DEVENV_TOOL_BOOT_PARAM: Self = Self(0x78020300);
     pub const DEVENV_TOOL_TRC_NOTIFY: Self = Self(0x78026400);
-    pub const DEVENT_TOOL_USE_DEFAULT_LIB: Self = Self(0x78028300);
+    pub const DEVENV_TOOL_USE_DEFAULT_LIB: Self = Self(0x78028300);
     pub const DEVENV_TOOL_SYS_PRX_PRELOAD: Self = Self(0x78028A00);
     pub const DEVENV_TOOL_GAME_INTMEM_DBG: Self = Self(0x7802BF00);
 
@@ -37,7 +47,15 @@ impl RegKey {
 impl Display for RegKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match *self {
+            Self::REGISTRY_VERSION => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_version"),
+            Self::REGISTRY_INSTALL => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_install"),
+            Self::REGISTRY_UPDATE => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_update"),
+            Self::REGISTRY_NOT_SAVE => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_not_save"),
             Self::REGISTRY_RECOVER => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_recover"),
+            Self::REGISTRY_DOWNGRADE => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_downgrade"),
+            Self::REGISTRY_BOOTCOUNT => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_bootcount"),
+            Self::REGISTRY_LASTVER => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_lastver"),
+            Self::REGISTRY_INIT_FLAG => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_init_flag"),
             Self::SYSTEM_UPDATE_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_update_mode"),
             Self::SYSTEM_POWER_SHUTDOWN_STATUS => {
                 f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_POWER_shutdown_status")
@@ -62,8 +80,21 @@ impl Display for RegKey {
             }
             Self::AUDIOOUT_CODEC => f.write_str("SCE_REGMGR_ENT_KEY_AUDIOOUT_codec"),
             Self::NET_WIFI_FREQ_BAND => f.write_str("SCE_REGMGR_ENT_KEY_NET_WIFI_freq_band"),
+            Self::NP_DEBUG => f.write_str("SCE_REGMGR_ENT_KEY_NP_debug"),
+            Self::BROWSER_DEBUG_NOTIFICATION => {
+                f.write_str("SCE_REGMGR_ENT_KEY_BROWSER_DEBUG_notification")
+            }
             Self::DEVENV_TOOL_BOOT_PARAM => {
                 f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_boot_param")
+            }
+            Self::DEVENV_TOOL_TRC_NOTIFY => {
+                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_trc_notify")
+            }
+            Self::DEVENV_TOOL_USE_DEFAULT_LIB => {
+                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_use_default_lib")
+            }
+            Self::DEVENV_TOOL_SYS_PRX_PRELOAD => {
+                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_sys_prx_preload")
             }
             Self::DEVENV_TOOL_GAME_INTMEM_DBG => {
                 f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_game_intmem_dbg")

--- a/src/kernel/src/regmgr/key.rs
+++ b/src/kernel/src/regmgr/key.rs
@@ -7,7 +7,6 @@ pub struct RegKey(u32);
 
 #[allow(dead_code)] // Removes complaints about unused Regkeys.
 impl RegKey {
-    // pub const REGISTRY_VERSION: Self = Self(0);
     pub const REGISTRY_VERSION: Self = Self(0x01010000);
     pub const REGISTRY_INSTALL: Self = Self(0x01020000);
     pub const REGISTRY_UPDATE: Self = Self(0x01030000);
@@ -18,6 +17,25 @@ impl RegKey {
     pub const REGISTRY_LASTVER: Self = Self(0x01080000);
     pub const REGISTRY_INIT_FLAG: Self = Self(0x01400000);
     pub const SYSTEM_UPDATE_MODE: Self = Self(0x02010000);
+    pub const SYSTEM_LANGUAGE: Self = Self(0x02020000);
+    pub const SYSTEM_INITIALIZE: Self = Self(0x02040000);
+    pub const SYSTEM_NICKNAME: Self = Self(0x02050000);
+    pub const SYSTEM_DIMMER_INTERVAL: Self = Self(0x02060000);
+    pub const SYSTEM_EAPFUNCTION: Self = Self(0x02070000);
+    pub const SYSTEM_ENABLE_VOICERCG: Self = Self(0x02080000);
+    pub const SYSTEM_SOFT_VERSION: Self = Self(0x02090000);
+    pub const SYSTEM_PROFILECH_VER: Self = Self(0x020A0000);
+    pub const SYSTEM_BUTTON_ASSIGN: Self = Self(0x020B0000);
+    pub const SYSTEM_BACKUP_MODE: Self = Self(0x020C0000);
+    pub const SYSTEM_PON_MEMORY_TEST: Self = Self(0x020D0000);
+    pub const SYSTEM_GAME_REC_MODE: Self = Self(0x020E0000);
+    pub const SYSTEM_SHELL_FUNCTION: Self = Self(0x020F0000);
+    pub const SYSTEM_PAD_CONNECTION: Self = Self(0x02100000);
+    pub const SYSTEM_DATA_TRANSFER: Self = Self(0x02110000);
+    pub const SYSTEM_BASE_MODE_CLKUP: Self = Self(0x02120000);
+    pub const SYSTEM_NEO_VDDNB_VID_OFFSET: Self = Self(0x02400000);
+    pub const SYSTEM_TESTBUTTON_MODE: Self = Self(0x02410000);
+    pub const SYSTEM_TESTBUTTON_PARAM: Self = Self(0x02420000);
     pub const SYSTEM_POWER_SHUTDOWN_STATUS: Self = Self(0x02820E00);
     pub const SYSTEM_SPECIFIC_IDU_MODE: Self = Self(0x02860100);
     pub const SYSTEM_SPECIFIC_SHOW_MODE: Self = Self(0x02860200);
@@ -57,6 +75,39 @@ impl Display for RegKey {
             Self::REGISTRY_LASTVER => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_lastver"),
             Self::REGISTRY_INIT_FLAG => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_init_flag"),
             Self::SYSTEM_UPDATE_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_update_mode"),
+            Self::SYSTEM_LANGUAGE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_language"),
+            Self::SYSTEM_INITIALIZE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_initialize"),
+            Self::SYSTEM_NICKNAME => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_nickname"),
+            Self::SYSTEM_DIMMER_INTERVAL => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_dimmer_interval")
+            }
+            Self::SYSTEM_EAPFUNCTION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_eapfunction"),
+            Self::SYSTEM_ENABLE_VOICERCG => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_enable_voicercg")
+            }
+            Self::SYSTEM_SOFT_VERSION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_soft_version"),
+            Self::SYSTEM_PROFILECH_VER => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_profilech_ver"),
+            Self::SYSTEM_BUTTON_ASSIGN => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_button_assign"),
+            Self::SYSTEM_BACKUP_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_backup_mode"),
+            Self::SYSTEM_PON_MEMORY_TEST => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_pon_memory_test")
+            }
+            Self::SYSTEM_GAME_REC_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_game_rec_mode"),
+            Self::SYSTEM_SHELL_FUNCTION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_shell_function"),
+            Self::SYSTEM_PAD_CONNECTION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_pad_connection"),
+            Self::SYSTEM_DATA_TRANSFER => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_data_transfer"),
+            Self::SYSTEM_BASE_MODE_CLKUP => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_base_mode_clkup")
+            }
+            Self::SYSTEM_NEO_VDDNB_VID_OFFSET => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_neo_vddnb_vid_offset")
+            }
+            Self::SYSTEM_TESTBUTTON_MODE => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_testbutton_mode")
+            }
+            Self::SYSTEM_TESTBUTTON_PARAM => {
+                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_testbutton_param")
+            }
             Self::SYSTEM_POWER_SHUTDOWN_STATUS => {
                 f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_POWER_shutdown_status")
             }

--- a/src/kernel/src/regmgr/mod.rs
+++ b/src/kernel/src/regmgr/mod.rs
@@ -252,7 +252,7 @@ impl RegMgr {
         };
 
         if entry.len > buf.len() {
-            return Err(RegError::V800d0208);
+            Err(RegError::V800d0208)
         } else if entry.unk5 == 2 {
             match entry.unk6 {
                 16 | 2 => todo!("regMgrComGetReg({key}) with unk6 = 16 | 2"),
@@ -332,7 +332,7 @@ impl RegMgr {
             RegKey::NP_DEBUG
             | RegKey::BROWSER_DEBUG_NOTIFICATION
             | RegKey::DEVENV_TOOL_TRC_NOTIFY
-            | RegKey::DEVENT_TOOL_USE_DEFAULT_LIB
+            | RegKey::DEVENV_TOOL_USE_DEFAULT_LIB
             | RegKey::DEVENV_TOOL_SYS_PRX_PRELOAD => {
                 let mut out = 0;
                 let ret = self.get_int(key, &mut out).unwrap();

--- a/src/kernel/src/rtld/mod.rs
+++ b/src/kernel/src/rtld/mod.rs
@@ -342,7 +342,7 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
         let mut sha1 = Sha1::new();
 
         sha1.update(name.as_bytes());
-        sha1.update(&Self::NID_SALT);
+        sha1.update(Self::NID_SALT);
 
         // Get NID.
         let hash = u64::from_ne_bytes(sha1.finalize()[..8].try_into().unwrap());
@@ -431,7 +431,7 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
         Ok(SysOut::ZERO)
     }
 
-    fn sys_dynlib_do_copy_relocations(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
+    fn sys_dynlib_do_copy_relocations(self: &Arc<Self>, _i: &SysIn) -> Result<SysOut, SysErr> {
         if let Some(info) = self.app.file_info() {
             for reloc in info.relocs() {
                 if reloc.ty() == Relocation::R_X86_64_COPY {
@@ -741,13 +741,13 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
         if flags & 2 == 0 || !md.flags().contains(ModuleFlags::UNK1) {
             let name = md.path().file_name().unwrap();
 
-            (*info).name[..name.len()].copy_from_slice(name.as_bytes());
-            (*info).name[0xff] = 0;
+            info.name[..name.len()].copy_from_slice(name.as_bytes());
+            info.name[0xff] = 0;
         }
 
         // Set TLS information. Not sure if the tlsinit can be zero when the tlsinitsize is zero.
         // Let's keep the same behavior as the PS4 for now.
-        (*info).tlsindex = if flags & 1 != 0 {
+        info.tlsindex = if flags & 1 != 0 {
             let flags = md.flags();
             let mut upper = if flags.contains(ModuleFlags::UNK1) {
                 1
@@ -765,30 +765,30 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
         };
 
         if let Some(i) = md.tls_info() {
-            (*info).tlsinit = addr + i.init();
-            (*info).tlsinitsize = i.init_size().try_into().unwrap();
-            (*info).tlssize = i.size().try_into().unwrap();
-            (*info).tlsalign = i.align().try_into().unwrap();
+            info.tlsinit = addr + i.init();
+            info.tlsinitsize = i.init_size().try_into().unwrap();
+            info.tlssize = i.size().try_into().unwrap();
+            info.tlsalign = i.align().try_into().unwrap();
         } else {
-            (*info).tlsinit = addr;
+            info.tlsinit = addr;
         }
 
-        (*info).tlsoffset = (*md.tls_offset()).try_into().unwrap();
+        info.tlsoffset = (*md.tls_offset()).try_into().unwrap();
 
         // Initialization and finalization functions.
         if !md.flags().contains(ModuleFlags::UNK5) {
-            (*info).init = md.init().map(|v| addr + v).unwrap_or(0);
-            (*info).fini = md.fini().map(|v| addr + v).unwrap_or(0);
+            info.init = md.init().map(|v| addr + v).unwrap_or(0);
+            info.fini = md.fini().map(|v| addr + v).unwrap_or(0);
         }
 
         // Exception handling.
         if let Some(i) = md.eh_info() {
-            (*info).eh_frame_hdr = addr + i.header();
-            (*info).eh_frame_hdr_size = i.header_size().try_into().unwrap();
-            (*info).eh_frame = addr + i.frame();
-            (*info).eh_frame_size = i.frame_size().try_into().unwrap();
+            info.eh_frame_hdr = addr + i.header();
+            info.eh_frame_hdr_size = i.header_size().try_into().unwrap();
+            info.eh_frame = addr + i.frame();
+            info.eh_frame_size = i.frame_size().try_into().unwrap();
         } else {
-            (*info).eh_frame_hdr = addr;
+            info.eh_frame_hdr = addr;
         }
 
         let mut e = info!();
@@ -800,16 +800,16 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
             handle
         )
         .unwrap();
-        writeln!(e, "mapbase     : {:#x}", (*info).mapbase).unwrap();
-        writeln!(e, "textsize    : {:#x}", (*info).textsize).unwrap();
-        writeln!(e, "database    : {:#x}", (*info).database).unwrap();
-        writeln!(e, "datasize    : {:#x}", (*info).datasize).unwrap();
-        writeln!(e, "tlsindex    : {}", (*info).tlsindex).unwrap();
-        writeln!(e, "tlsinit     : {:#x}", (*info).tlsinit).unwrap();
-        writeln!(e, "tlsoffset   : {:#x}", (*info).tlsoffset).unwrap();
-        writeln!(e, "init        : {:#x}", (*info).init).unwrap();
-        writeln!(e, "fini        : {:#x}", (*info).fini).unwrap();
-        writeln!(e, "eh_frame_hdr: {:#x}", (*info).eh_frame_hdr).unwrap();
+        writeln!(e, "mapbase     : {:#x}", info.mapbase).unwrap();
+        writeln!(e, "textsize    : {:#x}", info.textsize).unwrap();
+        writeln!(e, "database    : {:#x}", info.database).unwrap();
+        writeln!(e, "datasize    : {:#x}", info.datasize).unwrap();
+        writeln!(e, "tlsindex    : {}", info.tlsindex).unwrap();
+        writeln!(e, "tlsinit     : {:#x}", info.tlsinit).unwrap();
+        writeln!(e, "tlsoffset   : {:#x}", info.tlsoffset).unwrap();
+        writeln!(e, "init        : {:#x}", info.init).unwrap();
+        writeln!(e, "fini        : {:#x}", info.fini).unwrap();
+        writeln!(e, "eh_frame_hdr: {:#x}", info.eh_frame_hdr).unwrap();
 
         print(e);
 

--- a/src/kernel/src/rtld/resolver.rs
+++ b/src/kernel/src/rtld/resolver.rs
@@ -205,7 +205,7 @@ impl<'a, E: ExecutionEngine> SymbolResolver<'a, E> {
     /// See `symlook_obj` on the PS4 for a reference.
     pub fn resolve_from_module(
         &self,
-        refmod: &'a Arc<Module<E>>,
+        _refmod: &'a Arc<Module<E>>,
         name: Option<&str>,
         decoded_name: Option<&str>,
         symmod: Option<&str>,

--- a/src/kernel/src/sysctl/mod.rs
+++ b/src/kernel/src/sysctl/mod.rs
@@ -70,7 +70,7 @@ impl Sysctl {
         let newlen: usize = i.args[5].into();
 
         // Convert name to a slice.
-        let name = if namelen < 2 || namelen > 24 {
+        let name = if !(2..=24).contains(&namelen) {
             return Err(SysErr::Raw(EINVAL));
         } else if name.is_null() {
             return Err(SysErr::Raw(EFAULT));
@@ -229,7 +229,7 @@ impl Sysctl {
         }
 
         // Remove '.' at the end if present.
-        if name.chars().last().unwrap() == '.' {
+        if name.ends_with('.') {
             name.pop();
         }
 


### PR DESCRIPTION
Added Syscall 69 and 70, along with adding regkeys from 0x01010000 to 0x02420000, and adding the missing Display for `DEVENV_TOOL_USE_DEFAULT_LIB`, ending off with a use of `clippy --fix` to clean up any odd code.

Also here's your proof ultima:

![image](https://github.com/obhq/obliteration/assets/45863583/316adb1c-fdc9-45b0-8230-1d3f7c4ec6df)
