### PR TITLE
Fix unused initializations from Sysinfo

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -23,7 +23,7 @@ param = { path = "../param" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 sha1 = "0.10"
-sysinfo = "0.29.10"
+sysinfo = { version = "0.29.10", default-features = false }
 termcolor = "1.2.0"
 thiserror = "1.0"
 tls = { path = "../tls" }

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -118,7 +118,11 @@ fn main() -> ExitCode {
 
     // Show basic infomation.
     let mut log = info!();
-    let hwinfo = System::new_all();
+    let hwinfo = System::new_with_specifics(
+        sysinfo::RefreshKind::new()
+            .with_memory()
+            .with_cpu(sysinfo::CpuRefreshKind::new()),
+    );
 
     // Init information
     writeln!(log, "Starting Obliteration Kernel.").unwrap();


### PR DESCRIPTION
Using New_With_Specifics instead of just New, we now only initialize the CPU and RAM sysinfo, along with disabling the spam of threads. This takes us from 30 threads back to 5 threads!

Fixes #451 

@ultimaweapon 