### PR TITLE
Add safe slice for NAME2OID

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 bitflags = "2.1"
+bytemuck = "1.14.0"
 byteorder = "1.4"
 clap = { version = "4.1", features = ["derive"] }
 discord-rich-presence = "0.2"

--- a/src/kernel/src/sysctl/mod.rs
+++ b/src/kernel/src/sysctl/mod.rs
@@ -317,9 +317,8 @@ impl Sysctl {
             next = oid.arg1.unwrap().downcast_ref::<OidList>().unwrap().first;
         }
 
-        // TODO: Is it possible to use safe alternative here?
         let buf = &buf[..len];
-        let data: &[u8] = unsafe { std::slice::from_raw_parts(buf.as_ptr() as _, buf.len() * 4) };
+        let data: &[u8] = bytemuck::cast_slice(buf);
 
         req.write(data)
     }


### PR DESCRIPTION
Using Bytemuck, the slice for Name2OID is now safe. I did test and yes, it works.