### PR TITLE
Changes auth info for the process

### DIFF
--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -11,6 +11,7 @@ use crate::regmgr::RegMgr;
 use crate::rtld::{LoadFlags, ModuleFlags, RuntimeLinker};
 use crate::syscalls::Syscalls;
 use crate::sysctl::Sysctl;
+use crate::ucred::{AuthInfo, Ucred};
 use clap::{Parser, ValueEnum};
 use llt::Thread;
 use macros::vpath;
@@ -332,8 +333,9 @@ fn run<E: crate::ee::ExecutionEngine>(
     // Spawn main thread.
     info!("Starting application.");
 
+    let cred = Ucred::new(AuthInfo::SYS_CORE.clone());
     let stack = mm.stack();
-    let runner = match unsafe { vp.new_thread(stack.start(), stack.len(), entry) } {
+    let runner = match unsafe { vp.new_thread(cred, stack.start(), stack.len(), entry) } {
         Ok(v) => v,
         Err(e) => {
             error!(e, "Create main thread failed");

--- a/src/kernel/src/process/mod.rs
+++ b/src/kernel/src/process/mod.rs
@@ -65,7 +65,7 @@ impl VProc {
         let vp = Arc::new(Self {
             id: Self::new_id(),
             threads: mg.new_member(Vec::new()),
-            cred: Ucred::new(AuthInfo::SYS_CORE.clone()),
+            cred: Ucred::new(AuthInfo::GAME.clone()),
             group: mg.new_member(None),
             sigacts: mg.new_member(SignalActs::new()),
             files: FileDesc::new(&mg),
@@ -146,6 +146,7 @@ impl VProc {
     /// of the thread. Specify an unaligned stack will cause undefined behavior.
     pub unsafe fn new_thread<F>(
         self: &Arc<Self>,
+        cred: Ucred,
         stack: *mut u8,
         stack_size: usize,
         mut routine: F,
@@ -156,9 +157,6 @@ impl VProc {
         // Lock the list before spawn the thread to prevent race condition if the new thread run
         // too fast and found out they is not in our list.
         let mut threads = self.threads.write();
-
-        // TODO: Check how ucred is constructed for a thread.
-        let cred = Ucred::new(AuthInfo::SYS_CORE.clone());
         let td = Arc::new(VThread::new(Self::new_id(), cred, &self.mtxg));
         let active = Box::new(ActiveThread {
             proc: self.clone(),

--- a/src/kernel/src/ucred/auth.rs
+++ b/src/kernel/src/ucred/auth.rs
@@ -26,8 +26,8 @@ impl AuthInfo {
         unk: [0; 0x40],
     };
 
-    pub const EXE: Self = Self {
-        paid: 0x3100000000000001,
+    pub const GAME: Self = Self {
+        paid: 0x3800000000000011, // https://github.com/flatz/pkg_pfs_tool/blob/main/src/self.h#L36
         caps: [
             0x2000038000000000,
             0x000000000000FF00,


### PR DESCRIPTION
From what I saw in the `kern_execve` the auth info for the process is calculated from the process image, not copied from the current thread. This use auth info from a Fake SELF, which we need to update to a proper one once @VocalFan got it from a retail game.

Related issue: #473.