### PR TITLE
Fix/Add Freqs

### DIFF
--- a/src/kernel/src/arch/mod.rs
+++ b/src/kernel/src/arch/mod.rs
@@ -15,7 +15,11 @@ impl MachDep {
     const I386_SET_IOPERM: u32 = 4;
     const AMD64_SET_FSBASE: u32 = 129;
 
-    const TSC_FREQ: u64 = 16000000000;
+    // PS4 / PS4 Slim
+    const TSC_FREQ: u64 = 1600000000;
+
+    // PS4 PRO (Neo) TODO
+    // const TSC_FREQ: u64 = 2130000000;
 
     pub fn new(sys: &mut Syscalls) -> Arc<Self> {
         let mach = Arc::new(Self {

--- a/src/kernel/src/arch/mod.rs
+++ b/src/kernel/src/arch/mod.rs
@@ -16,10 +16,10 @@ impl MachDep {
     const AMD64_SET_FSBASE: u32 = 129;
 
     // PS4 / PS4 Slim
-    const TSC_FREQ: u64 = 1600000000;
+    const TSC_FREQ: u64 = 1_600_000_000;
 
     // PS4 PRO (Neo) TODO
-    // const TSC_FREQ: u64 = 2130000000;
+    // const TSC_FREQ: u64 = 2_130_000_000;
 
     pub fn new(sys: &mut Syscalls) -> Arc<Self> {
         let mach = Arc::new(Self {


### PR DESCRIPTION
Fixes the frequency we currently use.

*There was an extra 0, so we basically told it the CPU was at 16GHz instead of 1.6GHz*

Along with that, I also put in comments for later the PS4 Pro/Neo frequency.