### PR TITLE
Refactor ioctl com

### DIFF
--- a/src/kernel/src/dmem/mod.rs
+++ b/src/kernel/src/dmem/mod.rs
@@ -17,9 +17,9 @@ impl DmemManager {
     }
 
     fn sys_dmem_container(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
-        let uptate: i32 = i.args[0].try_into().unwrap();
+        let update: i32 = i.args[0].try_into().unwrap();
 
-        if uptate != -1 {
+        if update != -1 {
             todo!("sys_dmem_container with update != -1");
         }
 

--- a/src/kernel/src/fs/dev/console.rs
+++ b/src/kernel/src/fs/dev/console.rs
@@ -1,5 +1,5 @@
 use crate::errno::Errno;
-use crate::fs::{VFile, VFileOps, VPath};
+use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
 use macros::vpath;
@@ -38,7 +38,7 @@ impl VFileOps for Console {
     fn ioctl(
         &self,
         _file: &VFile,
-        _com: u64,
+        _com: IoctlCom,
         _data: &mut [u8],
         _cred: &Ucred,
         _td: &VThread,

--- a/src/kernel/src/fs/dev/deci_tty6.rs
+++ b/src/kernel/src/fs/dev/deci_tty6.rs
@@ -1,5 +1,5 @@
 use crate::errno::Errno;
-use crate::fs::{VFile, VFileOps, VPath};
+use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
 use macros::vpath;
@@ -24,7 +24,7 @@ impl VFileOps for DeciTty6 {
     fn ioctl(
         &self,
         _: &crate::fs::VFile,
-        _: u64,
+        _: IoctlCom,
         _: &mut [u8],
         _: &Ucred,
         _: &VThread,

--- a/src/kernel/src/fs/dev/dipsw.rs
+++ b/src/kernel/src/fs/dev/dipsw.rs
@@ -1,7 +1,8 @@
 use crate::errno::{Errno, EINVAL};
-use crate::fs::{VFile, VFileOps, VPath};
+use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
+use crate::{_IOC, _IOR, _IOW, _IOWR};
 use byteorder::{LittleEndian, WriteBytesExt};
 use macros::vpath;
 use std::fmt::{Display, Formatter};
@@ -20,6 +21,17 @@ impl Dipsw {
     }
 }
 
+const COM1: IoctlCom = _IOW!(0x88, 1, i16); //TODO: figure out actual type
+const COM2: IoctlCom = _IOW!(0x88, 2, i16); //TODO: figure out actual type
+const COM3: IoctlCom = _IOWR!(0x88, 3, i64); //TODO: figure out actual type
+const COM4: IoctlCom = _IOW!(0x88, 4, [u8; 0x10]); //TODO: figure out actual type, probably a struct
+const COM5: IoctlCom = _IOW!(0x88, 5, [u8; 0x10]); //TODO: figure out actual type, probably a struct
+const COM6: IoctlCom = _IOR!(0x88, 6, i32);
+const COM7: IoctlCom = _IOR!(0x88, 7, i32); //TODO: figure out actual type
+const COM8: IoctlCom = _IOR!(0x88, 8, i64); //TODO: figure out actual type
+const COM9: IoctlCom = _IOR!(0x88, 9, i64); //TODO: figure out actual type
+const COM10: IoctlCom = _IOW!(0x88, 10, [u8; 0x10]); //TODO: figure out actual type, probably a struct
+
 impl VFileOps for Dipsw {
     fn write(
         &self,
@@ -34,26 +46,26 @@ impl VFileOps for Dipsw {
     fn ioctl(
         &self,
         _: &VFile,
-        com: u64,
+        com: IoctlCom,
         mut data: &mut [u8],
         _: &Ucred,
         _: &VThread,
     ) -> Result<(), Box<dyn Errno>> {
         match com {
-            0x40048806 => {
+            COM1 => todo!("dipsw ioctl 0x80028801"),
+            COM2 => todo!("dipsw ioctl 0x80028802"),
+            COM3 => todo!("dipsw ioctl 0xc0088803"),
+            COM4 => todo!("dipsw ioctl 0x80108804"),
+            COM5 => todo!("dipsw ioctl 0x80108805"),
+            COM6 => {
                 //todo write the correct value if unk_func1() = false and
                 // unk_func2() = true
                 data.write_i32::<LittleEndian>(false as i32).unwrap();
             }
-            0x40048807 => todo!("dipsw ioctl 0x40048807"),
-            0x40088808 => todo!("dipsw ioctl 0x40088808"),
-            0x40088809 => todo!("dipsw ioctl 0x40088809"),
-            0x80028801 => todo!("dipsw ioctl 0x80028801"),
-            0x80028802 => todo!("dipsw ioctl 0x80028802"),
-            0x80108804 => todo!("dipsw ioctl 0x80108804"),
-            0x80108805 => todo!("dipsw ioctl 0x80108805"),
-            0x8010880a => todo!("dipsw ioctl 0x8010880a"),
-            0xc0088803 => todo!("dipsw ioctl 0xc0088803"),
+            COM7 => todo!("dipsw ioctl 0x40048807"),
+            COM8 => todo!("dipsw ioctl 0x40088808"),
+            COM9 => todo!("dipsw ioctl 0x40088809"),
+            COM10 => todo!("dipsw ioctl 0x8010880a"),
             _ => return Err(Box::new(IoctlErr::InvalidCommand)),
         }
 

--- a/src/kernel/src/fs/dev/dipsw.rs
+++ b/src/kernel/src/fs/dev/dipsw.rs
@@ -24,13 +24,13 @@ impl Dipsw {
 const COM1: IoctlCom = _IOW!(0x88, 1, i16); //TODO: figure out actual type
 const COM2: IoctlCom = _IOW!(0x88, 2, i16); //TODO: figure out actual type
 const COM3: IoctlCom = _IOWR!(0x88, 3, i64); //TODO: figure out actual type
-const COM4: IoctlCom = _IOW!(0x88, 4, [u8; 0x10]); //TODO: figure out actual type, probably a struct
-const COM5: IoctlCom = _IOW!(0x88, 5, [u8; 0x10]); //TODO: figure out actual type, probably a struct
+const COM4: IoctlCom = _IOW!(0x88, 4, (i64, i64)); //TODO: figure out actual type, probably a struct
+const COM5: IoctlCom = _IOW!(0x88, 5, (i64, i64)); //TODO: figure out actual type, probably a struct
 const COM6: IoctlCom = _IOR!(0x88, 6, i32);
 const COM7: IoctlCom = _IOR!(0x88, 7, i32); //TODO: figure out actual type
 const COM8: IoctlCom = _IOR!(0x88, 8, i64); //TODO: figure out actual type
 const COM9: IoctlCom = _IOR!(0x88, 9, i64); //TODO: figure out actual type
-const COM10: IoctlCom = _IOW!(0x88, 10, [u8; 0x10]); //TODO: figure out actual type, probably a struct
+const COM10: IoctlCom = _IOW!(0x88, 10, (i64, i64)); //TODO: figure out actual type, probably a struct
 
 impl VFileOps for Dipsw {
     fn write(

--- a/src/kernel/src/fs/dev/dipsw.rs
+++ b/src/kernel/src/fs/dev/dipsw.rs
@@ -22,7 +22,7 @@ impl Dipsw {
 
 const COM1: IoctlCom = IoctlCom::iow::<i16>(0x88, 1); //TODO: figure out actual type
 const COM2: IoctlCom = IoctlCom::iow::<i16>(0x88, 2); //TODO: figure out actual type
-const COM3: IoctlCom = IoctlCom::iowr::<i16>(0x88, 3); //TODO: figure out actual type
+const COM3: IoctlCom = IoctlCom::iowr::<i64>(0x88, 3); //TODO: figure out actual type
 const COM4: IoctlCom = IoctlCom::iow::<(i64, i64)>(0x88, 4); //TODO: figure out actual type, probably a struct
 const COM5: IoctlCom = IoctlCom::iow::<(i64, i64)>(0x88, 5); //TODO: figure out actual type, probably a struct
 const COM6: IoctlCom = IoctlCom::ior::<i32>(0x88, 6);

--- a/src/kernel/src/fs/dev/dipsw.rs
+++ b/src/kernel/src/fs/dev/dipsw.rs
@@ -2,7 +2,6 @@ use crate::errno::{Errno, EINVAL};
 use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
-use crate::{_IOC, _IOR, _IOW, _IOWR};
 use byteorder::{LittleEndian, WriteBytesExt};
 use macros::vpath;
 use std::fmt::{Display, Formatter};
@@ -21,16 +20,16 @@ impl Dipsw {
     }
 }
 
-const COM1: IoctlCom = _IOW!(0x88, 1, i16); //TODO: figure out actual type
-const COM2: IoctlCom = _IOW!(0x88, 2, i16); //TODO: figure out actual type
-const COM3: IoctlCom = _IOWR!(0x88, 3, i64); //TODO: figure out actual type
-const COM4: IoctlCom = _IOW!(0x88, 4, (i64, i64)); //TODO: figure out actual type, probably a struct
-const COM5: IoctlCom = _IOW!(0x88, 5, (i64, i64)); //TODO: figure out actual type, probably a struct
-const COM6: IoctlCom = _IOR!(0x88, 6, i32);
-const COM7: IoctlCom = _IOR!(0x88, 7, i32); //TODO: figure out actual type
-const COM8: IoctlCom = _IOR!(0x88, 8, i64); //TODO: figure out actual type
-const COM9: IoctlCom = _IOR!(0x88, 9, i64); //TODO: figure out actual type
-const COM10: IoctlCom = _IOW!(0x88, 10, (i64, i64)); //TODO: figure out actual type, probably a struct
+const COM1: IoctlCom = IoctlCom::iow::<i16>(0x88, 1); //TODO: figure out actual type
+const COM2: IoctlCom = IoctlCom::iow::<i16>(0x88, 2); //TODO: figure out actual type
+const COM3: IoctlCom = IoctlCom::iowr::<i16>(0x88, 3); //TODO: figure out actual type
+const COM4: IoctlCom = IoctlCom::iow::<(i64, i64)>(0x88, 4); //TODO: figure out actual type, probably a struct
+const COM5: IoctlCom = IoctlCom::iow::<(i64, i64)>(0x88, 5); //TODO: figure out actual type, probably a struct
+const COM6: IoctlCom = IoctlCom::ior::<i32>(0x88, 6);
+const COM7: IoctlCom = IoctlCom::ior::<i32>(0x88, 7); //TODO: figure out actual type
+const COM8: IoctlCom = IoctlCom::ior::<i64>(0x88, 8); //TODO: figure out actual type
+const COM9: IoctlCom = IoctlCom::ior::<i64>(0x88, 9); //TODO: figure out actual type
+const COM10: IoctlCom = IoctlCom::iow::<(i64, i64)>(0x88, 10); //TODO: figure out actual type, probably a struct
 
 impl VFileOps for Dipsw {
     fn write(

--- a/src/kernel/src/fs/dev/dmem0.rs
+++ b/src/kernel/src/fs/dev/dmem0.rs
@@ -1,5 +1,5 @@
 use crate::errno::Errno;
-use crate::fs::{VFile, VFileOps, VPath};
+use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
 use macros::vpath;
@@ -24,7 +24,7 @@ impl VFileOps for Dmem0 {
     fn ioctl(
         &self,
         _: &crate::fs::VFile,
-        _: u64,
+        _: IoctlCom,
         _: &mut [u8],
         _: &Ucred,
         _: &VThread,

--- a/src/kernel/src/fs/dev/dmem1.rs
+++ b/src/kernel/src/fs/dev/dmem1.rs
@@ -1,5 +1,5 @@
 use crate::errno::Errno;
-use crate::fs::{VFile, VFileOps, VPath};
+use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
 use macros::vpath;
@@ -24,7 +24,7 @@ impl VFileOps for Dmem1 {
     fn ioctl(
         &self,
         _: &crate::fs::VFile,
-        _: u64,
+        _: IoctlCom,
         _: &mut [u8],
         _: &Ucred,
         _: &VThread,

--- a/src/kernel/src/fs/dev/dmem1.rs
+++ b/src/kernel/src/fs/dev/dmem1.rs
@@ -24,7 +24,7 @@ impl VFileOps for Dmem1 {
     fn ioctl(
         &self,
         _: &crate::fs::VFile,
-        _: IoctlCom,
+        _com: IoctlCom,
         _: &mut [u8],
         _: &Ucred,
         _: &VThread,

--- a/src/kernel/src/fs/dev/dmem2.rs
+++ b/src/kernel/src/fs/dev/dmem2.rs
@@ -1,5 +1,5 @@
 use crate::errno::Errno;
-use crate::fs::{VFile, VFileOps, VPath};
+use crate::fs::{IoctlCom, VFile, VFileOps, VPath};
 use crate::process::VThread;
 use crate::ucred::Ucred;
 use macros::vpath;
@@ -24,7 +24,7 @@ impl VFileOps for Dmem2 {
     fn ioctl(
         &self,
         _: &crate::fs::VFile,
-        _: u64,
+        _: IoctlCom,
         _: &mut [u8],
         _: &Ucred,
         _: &VThread,

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -103,16 +103,6 @@ impl IoctlCom {
         Some(Self(com))
     }
 
-    const fn new(inout: u32, group: u8, num: u8, len: usize) -> Self {
-        let len: u32 = if len > (u32::MAX) as usize {
-            panic!("IOCPARM_LEN is too large");
-        } else {
-            len as u32
-        };
-
-        Self(inout | ((len & Self::IOCPARM_MASK) << 16) | ((group as u32) << 8) | (num as u32))
-    }
-
     pub fn size(&self) -> usize {
         Self::iocparm_len(self.0)
     }
@@ -142,7 +132,13 @@ impl IoctlCom {
     }
 
     pub const fn ioc(inout: u32, group: u8, num: u8, len: usize) -> Self {
-        Self::new(inout, group, num, len)
+        let len: u32 = if len > (u32::MAX) as usize {
+            panic!("IOCPARM_LEN is too large");
+        } else {
+            len as u32
+        };
+
+        Self(inout | ((len & Self::IOCPARM_MASK) << 16) | ((group as u32) << 8) | (num as u32))
     }
 
     pub const fn io(group: u8, num: u8) -> Self {

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -114,7 +114,7 @@ impl IoctlCom {
     }
 
     pub fn size(&self) -> usize {
-        ((self.0 >> 16) & Self::IOCPARM_MASK) as usize
+        Self::iocparm_len(self.0) as usize
     }
 
     pub fn is_void(&self) -> bool {

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -130,11 +130,19 @@ impl IoctlCom {
     }
 
     pub const fn is_invalid(com: u32) -> bool {
-        (com & (Self::IOC_VOID | Self::IOC_IN | Self::IOC_OUT) == 0)
-            || (com & (Self::IOC_IN | Self::IOC_OUT)) != 0 && Self::iocparm_len(com) == 0
-            || (com & Self::IOC_VOID != 0
-                && Self::iocparm_len(com) != 0
-                && Self::iocparm_len(com) != 4)
+        if com & (Self::IOC_VOID | Self::IOC_IN | Self::IOC_OUT) == 0 {
+            return false;
+        }
+
+        if com & (Self::IOC_IN | Self::IOC_OUT) != 0 && Self::iocparm_len(com) == 0 {
+            return false;
+        }
+
+        if com & Self::IOC_VOID != 0 && Self::iocparm_len(com) != 0 && Self::iocparm_len(com) != 4 {
+            return false;
+        }
+
+        true
     }
 
     pub const fn iocparm_len(com: u32) -> usize {

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -1,6 +1,7 @@
 use super::Fs;
-use crate::errno::Errno;
+use crate::errno::{Errno, ENOTTY};
 use crate::process::VThread;
+use crate::syscalls::{SysArg, SysErr};
 use crate::ucred::Ucred;
 use bitflags::bitflags;
 use std::fmt::{Debug, Display, Formatter};
@@ -166,6 +167,14 @@ impl IoctlCom {
 
     pub const fn iowr<T>(group: u8, num: u8) -> Self {
         Self::new(Self::IOC_INOUT, group, num, std::mem::size_of::<T>())
+    }
+}
+
+impl TryFrom<SysArg> for IoctlCom {
+    type Error = SysErr;
+
+    fn try_from(v: SysArg) -> Result<IoctlCom, Self::Error> {
+        IoctlCom::try_from_raw(v.into()).ok_or(SysErr::Raw(ENOTTY))
     }
 }
 

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -1,7 +1,6 @@
 use super::Fs;
-use crate::errno::{Errno, ENOTTY};
+use crate::errno::Errno;
 use crate::process::VThread;
-use crate::syscalls::SysErr;
 use crate::ucred::Ucred;
 use bitflags::bitflags;
 use std::fmt::{Debug, Display, Formatter};

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -93,7 +93,7 @@ impl IoctlCom {
     pub const IOC_IN: u32 = 0x80000000;
     pub const IOC_INOUT: u32 = Self::IOC_IN | Self::IOC_OUT;
 
-    pub const fn from_raw(com: u64) -> Result<Self, SysErr> {
+    pub const fn try_from_raw(com: u64) -> Result<Self, SysErr> {
         let com = com as u32;
 
         if Self::is_invalid(com) {

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -103,6 +103,16 @@ impl IoctlCom {
         Some(Self(com))
     }
 
+    const fn new(inout: u32, group: u8, num: u8, len: usize) -> Self {
+        let len: u32 = if len > (u32::MAX) as usize {
+            panic!("IOCPARM_LEN is too large");
+        } else {
+            len as u32
+        };
+
+        Self(inout | ((len & Self::IOCPARM_MASK) << 16) | ((group as u32) << 8) | (num as u32))
+    }
+
     pub fn size(&self) -> usize {
         Self::iocparm_len(self.0)
     }
@@ -131,34 +141,24 @@ impl IoctlCom {
         ((com >> 16) & Self::IOCPARM_MASK) as usize
     }
 
-    pub const fn ioc(inout: u32, group: u8, num: u8, len: usize) -> Self {
-        let len: u32 = if len > (u32::MAX) as usize {
-            panic!("IOCPARM_LEN is too large");
-        } else {
-            len as u32
-        };
-
-        Self(inout | ((len & Self::IOCPARM_MASK) << 16) | ((group as u32) << 8) | (num as u32))
-    }
-
     pub const fn io(group: u8, num: u8) -> Self {
-        Self::ioc(Self::IOC_VOID, group, num, 0)
+        Self::new(Self::IOC_VOID, group, num, 0)
     }
 
     pub const fn iowint(group: u8, num: u8) -> Self {
-        Self::ioc(Self::IOC_VOID, group, num, std::mem::size_of::<i32>())
+        Self::new(Self::IOC_VOID, group, num, std::mem::size_of::<i32>())
     }
 
     pub const fn ior<T>(group: u8, num: u8) -> Self {
-        Self::ioc(Self::IOC_OUT, group, num, std::mem::size_of::<T>())
+        Self::new(Self::IOC_OUT, group, num, std::mem::size_of::<T>())
     }
 
     pub const fn iow<T>(group: u8, num: u8) -> Self {
-        Self::ioc(Self::IOC_IN, group, num, std::mem::size_of::<T>())
+        Self::new(Self::IOC_IN, group, num, std::mem::size_of::<T>())
     }
 
     pub const fn iowr<T>(group: u8, num: u8) -> Self {
-        Self::ioc(Self::IOC_INOUT, group, num, std::mem::size_of::<T>())
+        Self::new(Self::IOC_INOUT, group, num, std::mem::size_of::<T>())
     }
 }
 

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -137,7 +137,7 @@ impl IoctlCom {
                 && Self::iocparm_len(com) != 4)
     }
 
-    pub fn iocparm_len(com: u32) -> usize {
+    pub const fn iocparm_len(com: u32) -> usize {
         ((com >> 16) & Self::IOCPARM_MASK) as usize
     }
 

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -114,7 +114,7 @@ impl IoctlCom {
     }
 
     pub fn size(&self) -> usize {
-        Self::iocparm_len(self.0)
+        ((self.0 >> 16) & Self::IOCPARM_MASK) as usize
     }
 
     pub fn is_void(&self) -> bool {
@@ -129,7 +129,7 @@ impl IoctlCom {
         self.0 & Self::IOC_IN != 0
     }
 
-    pub const fn is_invalid(com: u32) -> bool {
+    const fn is_invalid(com: u32) -> bool {
         if com & (Self::IOC_VOID | Self::IOC_IN | Self::IOC_OUT) == 0 {
             return false;
         }
@@ -145,7 +145,7 @@ impl IoctlCom {
         true
     }
 
-    pub const fn iocparm_len(com: u32) -> usize {
+    const fn iocparm_len(com: u32) -> usize {
         ((com >> 16) & Self::IOCPARM_MASK) as usize
     }
 

--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -93,17 +93,17 @@ impl IoctlCom {
     pub const IOC_IN: u32 = 0x80000000;
     pub const IOC_INOUT: u32 = Self::IOC_IN | Self::IOC_OUT;
 
-    pub const fn try_from_raw(com: u64) -> Result<Self, SysErr> {
+    pub const fn try_from_raw(com: u64) -> Option<Self> {
         let com = com as u32;
 
         if Self::is_invalid(com) {
-            return Err(SysErr::Raw(ENOTTY));
+            return None;
         }
 
-        Ok(Self(com))
+        Some(Self(com))
     }
 
-    pub const fn new(inout: u32, group: u8, num: u8, len: usize) -> Self {
+    const fn new(inout: u32, group: u8, num: u8, len: usize) -> Self {
         let len: u32 = if len > (u32::MAX) as usize {
             panic!("IOCPARM_LEN is too large");
         } else {
@@ -150,7 +150,7 @@ impl IoctlCom {
     }
 
     pub const fn iowint(group: u8, num: u8) -> Self {
-        Self::ioc(Self::IOC_IN, group, num, std::mem::size_of::<i32>())
+        Self::ioc(Self::IOC_VOID, group, num, std::mem::size_of::<i32>())
     }
 
     pub const fn ior<T>(group: u8, num: u8) -> Self {

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -311,10 +311,10 @@ impl Fs {
         Ok(SysOut::ZERO)
     }
 
-    const UNK_COM1: IoctlCom = _IO!(0x66, 1);
-    const UNK_COM2: IoctlCom = _IO!(0x66, 2);
-    const UNK_COM3: IoctlCom = _IOWINT!(0x66, 0x7e);
-    const UNK_COM4: IoctlCom = _IOWINT!(0x66, 0x7d);
+    const UNK_COM1: IoctlCom = _IO!(b'f', 1);
+    const UNK_COM2: IoctlCom = _IO!(b'f', 2);
+    const UNK_COM3: IoctlCom = _IOWINT!(b'f', 0x7e);
+    const UNK_COM4: IoctlCom = _IOWINT!(b'f', 0x7d);
 
     fn sys_ioctl(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
         let fd: i32 = i.args[0].try_into().unwrap();

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -22,7 +22,6 @@ use std::sync::{Arc, RwLock};
 use thiserror::Error;
 
 mod dev;
-#[macro_use]
 mod file;
 mod host;
 mod item;

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -300,10 +300,10 @@ impl Fs {
         Ok(SysOut::ZERO)
     }
 
-    const UNK_COM1: IoctlCom = _IO!(b'f', 1);
-    const UNK_COM2: IoctlCom = _IO!(b'f', 2);
-    const UNK_COM3: IoctlCom = _IOWINT!(b'f', 0x7e);
-    const UNK_COM4: IoctlCom = _IOWINT!(b'f', 0x7d);
+    const UNK_COM1: IoctlCom = IoctlCom::io(b'f', 1);
+    const UNK_COM2: IoctlCom = IoctlCom::io(b'f', 2);
+    const UNK_COM3: IoctlCom = IoctlCom::iowint(b'f', 0x7e);
+    const UNK_COM4: IoctlCom = IoctlCom::iowint(b'f', 0x7d);
 
     fn sys_ioctl(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
         let fd: i32 = i.args[0].try_into().unwrap();

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -318,14 +318,10 @@ impl Fs {
 
     fn sys_ioctl(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
         let fd: i32 = i.args[0].try_into().unwrap();
-        let com: IoctlCom = i.args[1].into();
+        let com: IoctlCom = i.args[1].try_into()?;
         let data_arg: *mut u8 = i.args[2].into();
 
         let size: usize = com.size();
-
-        if com.is_invalid() {
-            return Err(SysErr::Raw(ENOTTY));
-        }
 
         let mut vec = vec![0u8; size];
 

--- a/src/kernel/src/syscalls/input.rs
+++ b/src/kernel/src/syscalls/input.rs
@@ -1,6 +1,6 @@
 use super::SysErr;
 use crate::errno::{ENAMETOOLONG, ENOENT};
-use crate::fs::{VPath, VPathBuf};
+use crate::fs::{IoctlCom, VPath, VPathBuf};
 use std::ffi::{c_char, CStr};
 use std::fmt::{Formatter, LowerHex};
 use std::num::TryFromIntError;
@@ -124,5 +124,11 @@ impl TryFrom<SysArg> for u8 {
 
     fn try_from(v: SysArg) -> Result<Self, Self::Error> {
         v.0.try_into()
+    }
+}
+
+impl From<SysArg> for IoctlCom {
+    fn from(v: SysArg) -> Self {
+        IoctlCom::new_truncated(v.try_into().unwrap())
     }
 }

--- a/src/kernel/src/syscalls/input.rs
+++ b/src/kernel/src/syscalls/input.rs
@@ -1,5 +1,5 @@
 use super::SysErr;
-use crate::errno::{ENAMETOOLONG, ENOENT};
+use crate::errno::{ENAMETOOLONG, ENOENT, ENOTTY};
 use crate::fs::{IoctlCom, VPath, VPathBuf};
 use std::ffi::{c_char, CStr};
 use std::fmt::{Formatter, LowerHex};
@@ -131,6 +131,6 @@ impl TryFrom<SysArg> for IoctlCom {
     type Error = SysErr;
 
     fn try_from(v: SysArg) -> Result<IoctlCom, Self::Error> {
-        IoctlCom::try_from_raw(v.try_into().unwrap())
+        IoctlCom::try_from_raw(v.into()).ok_or(SysErr::Raw(ENOTTY))
     }
 }

--- a/src/kernel/src/syscalls/input.rs
+++ b/src/kernel/src/syscalls/input.rs
@@ -127,8 +127,10 @@ impl TryFrom<SysArg> for u8 {
     }
 }
 
-impl From<SysArg> for IoctlCom {
-    fn from(v: SysArg) -> Self {
-        IoctlCom::new_truncated(v.try_into().unwrap())
+impl TryFrom<SysArg> for IoctlCom {
+    type Error = SysErr;
+
+    fn try_from(v: SysArg) -> Result<IoctlCom, Self::Error> {
+        IoctlCom::from_raw(v.try_into().unwrap())
     }
 }

--- a/src/kernel/src/syscalls/input.rs
+++ b/src/kernel/src/syscalls/input.rs
@@ -131,6 +131,6 @@ impl TryFrom<SysArg> for IoctlCom {
     type Error = SysErr;
 
     fn try_from(v: SysArg) -> Result<IoctlCom, Self::Error> {
-        IoctlCom::from_raw(v.try_into().unwrap())
+        IoctlCom::try_from_raw(v.try_into().unwrap())
     }
 }

--- a/src/kernel/src/syscalls/input.rs
+++ b/src/kernel/src/syscalls/input.rs
@@ -1,6 +1,6 @@
 use super::SysErr;
-use crate::errno::{ENAMETOOLONG, ENOENT, ENOTTY};
-use crate::fs::{IoctlCom, VPath, VPathBuf};
+use crate::errno::{ENAMETOOLONG, ENOENT};
+use crate::fs::{VPath, VPathBuf};
 use std::ffi::{c_char, CStr};
 use std::fmt::{Formatter, LowerHex};
 use std::num::TryFromIntError;
@@ -124,13 +124,5 @@ impl TryFrom<SysArg> for u8 {
 
     fn try_from(v: SysArg) -> Result<Self, Self::Error> {
         v.0.try_into()
-    }
-}
-
-impl TryFrom<SysArg> for IoctlCom {
-    type Error = SysErr;
-
-    fn try_from(v: SysArg) -> Result<IoctlCom, Self::Error> {
-        IoctlCom::try_from_raw(v.into()).ok_or(SysErr::Raw(ENOTTY))
     }
 }


### PR DESCRIPTION
Provides a wrapper type for the ioctl argument 'com' along with a couple of macros borrowed from FreeBSD for defining commands.