### PR TITLE
Always use latest version of Rust-Lang

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -51,6 +51,8 @@ jobs:
         print $fh "flatpak-branch=$name\n";
       shell: perl {0}
       id: flatpak-branch
+    - name: Update Rust-Lang
+      run: rustup update stable
     - name: Build Flatpak
       run: flatpak-builder --default-branch ${{ steps.flatpak-branch.outputs.flatpak-branch }} build flatpak.yml
     - name: Export Flatpak

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -101,6 +101,8 @@ jobs:
           fi
         done
       if: ${{ steps.qt-cache.outputs.cache-hit != 'true' }}
+    - name: Update Rust-Lang
+      run: rustup update stable
     - name: Run CMake
       run: cmake -DOB_BUILD_LLVM:BOOL=OFF --preset mac-release .
     - name: Build

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -97,6 +97,8 @@ jobs:
       if: ${{ steps.restore-vulkan.outputs.cache-hit != 'true' }}
     - name: Set Vulkan SDK path
       run:  echo "VULKAN_SDK=C:\VulkanSDK" >> $env:GITHUB_ENV
+    - name: Update Rust-Lang
+      run: rustup update stable
     - name: Run CMake
       run: cmake -DOB_BUILD_LLVM:BOOL=OFF --preset windows-release .
     - name: Build


### PR DESCRIPTION
Forces all 3 runners to run `rustup update stable` to ensure they're all running the latest stable version of Rust-Lang, should hopefully remove the error occurring on Mac and potentially different versions between runners.