### PR TITLE
Removes recursive lock checking from gutex

### DIFF
--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -4,7 +4,7 @@ pub use self::item::*;
 pub use self::mount::*;
 pub use self::path::*;
 pub use self::vnode::*;
-use crate::errno::{Errno, EBADF, EINVAL, ENAMETOOLONG, ENODEV, ENOENT, ENOTCAPABLE, ENOTTY};
+use crate::errno::{Errno, EBADF, EINVAL, ENAMETOOLONG, ENODEV, ENOENT, ENOTCAPABLE};
 use crate::info;
 use crate::process::{VProc, VThread};
 use crate::syscalls::{SysArg, SysErr, SysIn, SysOut, Syscalls};
@@ -81,7 +81,7 @@ impl Fs {
         opts.insert("param".into(), Box::new(param.clone()));
 
         // Mount root FS.
-        let gg = GutexGroup::new("fs");
+        let gg = GutexGroup::new();
         let fs = Arc::new(Self {
             vp: vp.clone(),
             mounts: gg.spawn(mounts),

--- a/src/kernel/src/fs/mount.rs
+++ b/src/kernel/src/fs/mount.rs
@@ -25,7 +25,7 @@ impl Mount {
     where
         P: Into<String>,
     {
-        let gg = GutexGroup::new("mount");
+        let gg = GutexGroup::new();
         let owner = cred.effective_uid();
         let mount = Self {
             fs,

--- a/src/kernel/src/fs/vnode.rs
+++ b/src/kernel/src/fs/vnode.rs
@@ -12,7 +12,7 @@ pub struct Vnode {
 
 impl Vnode {
     pub fn new(ty: Option<VnodeType>) -> Self {
-        let gg = GutexGroup::new("vnode");
+        let gg = GutexGroup::new();
 
         Self {
             ty: gg.spawn(ty),

--- a/src/kernel/src/process/mod.rs
+++ b/src/kernel/src/process/mod.rs
@@ -39,7 +39,8 @@ mod thread;
 ///
 /// Each process of the Obliteration Kernel encapsulate only one PS4 process. The reason we don't
 /// encapsulate multiple PS4 processes is because there is no way to emulate `fork` with 100%
-/// compatibility from the user-mode application.
+/// compatibility from the user-mode application. The PS4 also forbid the game process from creating
+/// a child process so no reason for us to support this.
 #[derive(Debug)]
 pub struct VProc {
     id: NonZeroI32,                                  // p_pid
@@ -62,7 +63,7 @@ pub struct VProc {
 impl VProc {
     pub fn new(auth: AuthInfo, sys: &mut Syscalls) -> Result<Arc<Self>, VProcError> {
         // TODO: Check how ucred is constructed for a process.
-        let gg = GutexGroup::new("virtual process");
+        let gg = GutexGroup::new();
         let limits = Self::load_limits()?;
         let vp = Arc::new(Self {
             id: Self::new_id(),

--- a/src/kernel/src/rtld/mod.rs
+++ b/src/kernel/src/rtld/mod.rs
@@ -217,7 +217,28 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
         force: bool,
         main: bool,
     ) -> Result<Arc<Module<E>>, LoadError<E>> {
-        // Get file before locking our gutex.
+        // Check if already loaded.
+        let name = path.file_name().unwrap().to_owned();
+        let mut list = self.list.write();
+
+        if !force {
+            if let Some(m) = list.iter().skip(1).find(|m| m.names().contains(&name)) {
+                return Ok(m.clone());
+            }
+        }
+
+        // Check if application is decid.(s)elf.
+        let app = self.app.path().file_name().unwrap();
+
+        if app != "decid.elf" && app != "decid.self" {
+            // TODO: Check what the PS4 is doing here.
+        }
+
+        if self.flags.intersects(LinkerFlags::HAS_SANITIZER) {
+            todo!("do_load_object with sanitizer & 2");
+        }
+
+        // Get file.
         let td = VThread::current();
         let mut nd = NameiData {
             dirp: path,
@@ -242,27 +263,6 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
             },
             Err(e) => return Err(LoadError::GetFileFailed(e)),
         };
-
-        // Check if already loaded.
-        let name = path.file_name().unwrap().to_owned();
-        let mut list = self.list.write();
-
-        if !force {
-            if let Some(m) = list.iter().skip(1).find(|m| m.names().contains(&name)) {
-                return Ok(m.clone());
-            }
-        }
-
-        // Check if application is decid.(s)elf.
-        let app = self.app.path().file_name().unwrap();
-
-        if app != "decid.elf" && app != "decid.self" {
-            // TODO: Check what the PS4 is doing here.
-        }
-
-        if self.flags.intersects(LinkerFlags::HAS_SANITIZER) {
-            todo!("do_load_object with sanitizer & 2");
-        }
 
         // Load (S)ELF.
         let elf = match File::open(file.path()) {
@@ -550,7 +550,9 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
 
         info!("Loading {name} with {flags:#x}.");
 
-        // TODO: Prevent race condition here.
+        // Start locking from here and keep the lock until we finished.
+        let mut globals = self.globals.write();
+
         // Check if already loaded.
         let list = self.list.read();
         let md = match list.iter().skip(1).find(|m| m.path() == name) {
@@ -570,8 +572,6 @@ impl<E: ExecutionEngine> RuntimeLinker<E> {
         };
 
         // Add to global list if it is not in the list yet.
-        let mut globals = self.globals.write();
-
         if globals.iter().find(|m| Arc::ptr_eq(m, &md)).is_none() {
             globals.push(md.clone());
         }


### PR DESCRIPTION
The reason is because it is prevent locking even if the lock that a thread trying to acquire does not acquire more lock after that. This also add some optimization.