### PR TITLE
Replaces VopVector with VnodeBackend

### DIFF
--- a/src/kernel/src/fs/dev/dirent.rs
+++ b/src/kernel/src/fs/dev/dirent.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
 /// An implementation of `devfs_dirent` structure.
+#[derive(Debug)]
 pub struct Dirent {
     inode: i32,                        // de_inode
     uid: Gutex<Uid>,                   // de_uid

--- a/src/kernel/src/fs/dev/vnode.rs
+++ b/src/kernel/src/fs/dev/vnode.rs
@@ -1,186 +1,189 @@
 use super::dirent::Dirent;
 use super::{alloc_vnode, AllocVnodeError, Cdev, DevFs};
 use crate::errno::{Errno, EIO, ENOENT, ENOTDIR, ENXIO};
-use crate::fs::{
-    check_access, Access, OpenFlags, VFile, Vnode, VnodeAttrs, VnodeType, VopVector,
-    DEFAULT_VNODEOPS,
-};
+use crate::fs::{check_access, Access, OpenFlags, VFile, Vnode, VnodeAttrs, VnodeType};
 use crate::process::VThread;
 use std::num::NonZeroI32;
 use std::sync::Arc;
 use thiserror::Error;
 
-pub static VNODE_OPS: VopVector = VopVector {
-    default: Some(&DEFAULT_VNODEOPS),
-    access: Some(access),
-    accessx: None,
-    getattr: Some(getattr),
-    lookup: Some(lookup),
-    open: None,
-};
+/// An implementation of [`crate::fs::VnodeBackend`] for devfs.
+///
+/// This implementation merge `devfs_vnodeops` and `devfs_specops` together.
+#[derive(Debug)]
+pub struct VnodeBackend {
+    fs: Arc<DevFs>,
+    dirent: Arc<Dirent>,
+}
 
-pub static CHARACTER_OPS: VopVector = VopVector {
-    default: Some(&DEFAULT_VNODEOPS),
-    access: Some(access),
-    accessx: None,
-    getattr: Some(getattr),
-    lookup: None,
-    open: Some(open),
-};
+impl VnodeBackend {
+    pub fn new(fs: Arc<DevFs>, dirent: Arc<Dirent>) -> Self {
+        Self { fs, dirent }
+    }
+}
 
-fn access(vn: &Arc<Vnode>, td: Option<&VThread>, access: Access) -> Result<(), Box<dyn Errno>> {
-    // Get dirent.
-    let mut dirent = vn.data().clone().downcast::<Dirent>().unwrap();
-    let is_dir = match vn.ty() {
-        VnodeType::Directory(_) => {
+impl crate::fs::VnodeBackend for VnodeBackend {
+    fn access(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        mode: Access,
+    ) -> Result<(), Box<dyn Errno>> {
+        // Get dirent.
+        let mut dirent = self.dirent.clone();
+        let is_dir = match vn.ty() {
+            VnodeType::Directory(_) => {
+                if let Some(v) = dirent.dir() {
+                    // Is it possible the parent will be gone here?
+                    dirent = v.upgrade().unwrap();
+                }
+
+                true
+            }
+            _ => false,
+        };
+
+        // Get credential.
+        let cred = match td {
+            Some(v) => v.cred(),
+            None => return Ok(()),
+        };
+
+        // Get file permissions as atomic.
+        let (fuid, fgid, fmode) = {
+            let uid = dirent.uid();
+            let gid = dirent.gid();
+            let mode = dirent.mode();
+
+            (*uid, *gid, *mode)
+        };
+
+        // Check access.
+        let err = match check_access(cred, fuid, fgid, fmode.into(), mode, is_dir) {
+            Ok(_) => return Ok(()),
+            Err(e) => e,
+        };
+
+        // TODO: Check if file is a controlling terminal.
+        Err(Box::new(err))
+    }
+
+    fn getattr(self: Arc<Self>, vn: &Arc<Vnode>) -> Result<VnodeAttrs, Box<dyn Errno>> {
+        // Populate devices.
+        self.fs.populate();
+
+        // Get dirent.
+        let mut dirent = self.dirent.clone();
+
+        if vn.is_directory() {
             if let Some(v) = dirent.dir() {
                 // Is it possible the parent will be gone here?
                 dirent = v.upgrade().unwrap();
             }
-
-            true
         }
-        _ => false,
-    };
 
-    // Get credential.
-    let cred = match td {
-        Some(v) => v.cred(),
-        None => return Ok(()),
-    };
-
-    // Get file permissions as atomic.
-    let (uid, gid, mode) = {
+        // Atomic get attributes.
         let uid = dirent.uid();
         let gid = dirent.gid();
         let mode = dirent.mode();
+        let size = match vn.ty() {
+            VnodeType::Directory(_) => 512,
+            VnodeType::Character => 0,
+        };
 
-        (*uid, *gid, *mode)
-    };
-
-    // Check access.
-    let err = match check_access(cred, uid, gid, mode.into(), access, is_dir) {
-        Ok(_) => return Ok(()),
-        Err(e) => e,
-    };
-
-    // TODO: Check if file is a controlling terminal.
-    return Err(Box::new(err));
-}
-
-fn getattr(vn: &Arc<Vnode>) -> Result<VnodeAttrs, Box<dyn Errno>> {
-    // Populate devices.
-    let fs = vn.fs().data().downcast_ref::<DevFs>().unwrap();
-
-    fs.populate();
-
-    // Get dirent.
-    let mut dirent = vn.data().clone().downcast::<Dirent>().unwrap();
-
-    if vn.is_directory() {
-        if let Some(v) = dirent.dir() {
-            // Is it possible the parent will be gone here?
-            dirent = v.upgrade().unwrap();
-        }
+        Ok(VnodeAttrs::new(*uid, *gid, *mode, size))
     }
 
-    // Atomic get attributes.
-    let uid = dirent.uid();
-    let gid = dirent.gid();
-    let mode = dirent.mode();
-    let size = match vn.ty() {
-        VnodeType::Directory(_) => 512,
-        VnodeType::Character => 0,
-    };
+    fn lookup(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        name: &str,
+    ) -> Result<Arc<Vnode>, Box<dyn Errno>> {
+        // Populate devices.
+        self.fs.populate();
 
-    Ok(VnodeAttrs::new(*uid, *gid, *mode, size))
-}
+        // Check if directory.
+        match vn.ty() {
+            VnodeType::Directory(root) => {
+                if name == ".." && *root {
+                    return Err(Box::new(LookupError::DotdotOnRoot));
+                }
+            }
+            _ => return Err(Box::new(LookupError::NotDirectory)),
+        }
 
-fn lookup(vn: &Arc<Vnode>, td: Option<&VThread>, name: &str) -> Result<Arc<Vnode>, Box<dyn Errno>> {
-    // Populate devices.
-    let fs = vn.fs().data().downcast_ref::<DevFs>().unwrap();
+        // Check if directory is accessible.
+        if let Err(e) = vn.access(td, Access::EXEC) {
+            return Err(Box::new(LookupError::AccessDenied(e)));
+        }
 
-    fs.populate();
+        // Check name.
+        match name {
+            "." => Ok(vn.clone()),
+            ".." => {
+                let parent = match self.dirent.parent() {
+                    Some(v) => v,
+                    None => return Err(Box::new(LookupError::NoParent)),
+                };
 
-    // Check if directory.
-    match vn.ty() {
-        VnodeType::Directory(root) => {
-            if name == ".." && *root {
-                return Err(Box::new(LookupError::DotdotOnRoot));
+                match alloc_vnode(vn.fs(), &parent) {
+                    Ok(v) => Ok(v),
+                    Err(e) => Err(Box::new(LookupError::AllocVnodeFailed(e))),
+                }
+            }
+            _ => {
+                // Lookup.
+                let item = match self.dirent.find(name, None) {
+                    Some(v) => {
+                        // TODO: Implement devfs_prison_check.
+                        v
+                    }
+                    None => todo!("devfs lookup with non-existent file"),
+                };
+
+                match alloc_vnode(vn.fs(), &item) {
+                    Ok(v) => Ok(v),
+                    Err(e) => Err(Box::new(LookupError::AllocVnodeFailed(e))),
+                }
             }
         }
-        _ => return Err(Box::new(LookupError::NotDirectory)),
     }
 
-    // Check if directory is accessible.
-    if let Err(e) = vn.access(td, Access::EXEC) {
-        return Err(Box::new(LookupError::AccessDenied(e)));
-    }
-
-    // Check name.
-    if name == "." {
-        return Ok(vn.clone());
-    }
-
-    let dirent = vn.data().downcast_ref::<Dirent>().unwrap();
-
-    if name == ".." {
-        let parent = match dirent.parent() {
-            Some(v) => v,
-            None => return Err(Box::new(LookupError::NoParent)),
-        };
-
-        return match alloc_vnode(vn.fs(), &parent) {
-            Ok(v) => Ok(v),
-            Err(e) => Err(Box::new(LookupError::AllocVnodeFailed(e))),
-        };
-    }
-
-    // Lookup.
-    let item = match dirent.find(name, None) {
-        Some(v) => {
-            // TODO: Implement devfs_prison_check.
-            v
+    fn open(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        mode: OpenFlags,
+        mut file: Option<&mut VFile>,
+    ) -> Result<(), Box<dyn Errno>> {
+        if !vn.is_character() {
+            return Ok(());
         }
-        None => todo!("devfs lookup with non-existent file"),
-    };
 
-    match alloc_vnode(vn.fs(), &item) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(Box::new(LookupError::AllocVnodeFailed(e))),
+        // Not sure why FreeBSD check if vnode is VBLK because all of vnode here always be VCHR.
+        let dev = vn.item().unwrap().downcast::<Cdev>().unwrap();
+        let sw = dev.sw();
+
+        if file.is_none() && sw.fdopen().is_some() {
+            return Err(Box::new(OpenError::NeedFile));
+        }
+
+        // Execute switch handler.
+        match sw.fdopen() {
+            Some(f) => f(&dev, mode, td, file.as_mut().map(|f| &mut **f))?,
+            None => sw.open().unwrap()(&dev, mode, 0x2000, td)?,
+        };
+
+        // Set file OP.
+        let file = match file {
+            Some(v) => v,
+            None => return Ok(()),
+        };
+
+        // TODO: Implement remaining logics from the PS4.
+        Ok(())
     }
-}
-
-fn open(
-    vn: &Arc<Vnode>,
-    td: Option<&VThread>,
-    mode: OpenFlags,
-    mut file: Option<&mut VFile>,
-) -> Result<(), Box<dyn Errno>> {
-    // Not sure why FreeBSD check if vnode is VBLK because all of vnode here always be VCHR.
-    let dev = vn.item().unwrap().downcast::<Cdev>().unwrap();
-    let sw = dev.sw();
-
-    assert!(vn.is_character());
-
-    if file.is_none() && sw.fdopen().is_some() {
-        return Err(Box::new(OpenError::NeedFile));
-    }
-
-    // Execute switch handler.
-    match sw.fdopen() {
-        Some(f) => f(&dev, mode, td, file.as_mut().map(|f| &mut **f))?,
-        None => sw.open().unwrap()(&dev, mode, 0x2000, td)?,
-    };
-
-    // Set file OP.
-    let file = match file {
-        Some(v) => v,
-        None => return Ok(()),
-    };
-
-    // TODO: Implement remaining logics from the PS4.
-    Ok(())
 }
 
 /// Represents an error when [`lookup()`] is failed.

--- a/src/kernel/src/fs/dirent.rs
+++ b/src/kernel/src/fs/dirent.rs
@@ -1,4 +1,5 @@
 /// An implementation of `dirent` structure.
+#[derive(Debug)]
 pub struct Dirent {
     ty: DirentType, // d_type
     name: String,   // d_name
@@ -26,7 +27,7 @@ impl Dirent {
 }
 
 /// Type of [`Dirent`].
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirentType {
     Character = 2, // DT_CHR
     Directory = 4, // DT_DIR

--- a/src/kernel/src/fs/host/file.rs
+++ b/src/kernel/src/fs/host/file.rs
@@ -3,6 +3,7 @@ use std::mem::zeroed;
 use std::path::{Path, PathBuf};
 
 /// Encapsulate a raw file or directory on the host.
+#[derive(Debug)]
 pub struct HostFile {
     path: PathBuf,
     raw: RawFile,

--- a/src/kernel/src/fs/host/mod.rs
+++ b/src/kernel/src/fs/host/mod.rs
@@ -1,5 +1,5 @@
 use self::file::HostFile;
-use self::vnode::VNODE_OPS;
+use self::vnode::VnodeBackend;
 use super::{FsConfig, FsOps, Mount, MountFlags, VPathBuf, Vnode, VnodeType};
 use crate::errno::{Errno, EIO};
 use crate::ucred::Ucred;
@@ -166,7 +166,12 @@ fn get_vnode(mnt: &Arc<Mount>, path: Option<&Path>) -> Result<Arc<Vnode>, GetVno
     };
 
     // Allocate a new vnode.
-    let vn = Arc::new(Vnode::new(mnt, ty, "exfatfs", &VNODE_OPS, Arc::new(file)));
+    let vn = Arc::new(Vnode::new(
+        mnt,
+        ty,
+        "exfatfs",
+        Arc::new(VnodeBackend::new(file)),
+    ));
 
     actives.insert(path.to_owned(), Arc::downgrade(&vn));
     drop(actives);

--- a/src/kernel/src/fs/host/vnode.rs
+++ b/src/kernel/src/fs/host/vnode.rs
@@ -1,9 +1,7 @@
 use super::file::HostFile;
 use super::{get_vnode, GetVnodeError};
 use crate::errno::{Errno, EIO, ENOENT, ENOTDIR};
-use crate::fs::{
-    Access, Mode, OpenFlags, VFile, Vnode, VnodeAttrs, VnodeType, VopVector, DEFAULT_VNODEOPS,
-};
+use crate::fs::{Access, Mode, OpenFlags, VFile, Vnode, VnodeAttrs, VnodeType};
 use crate::process::VThread;
 use crate::ucred::{Gid, Uid};
 use std::borrow::Cow;
@@ -11,86 +9,100 @@ use std::num::NonZeroI32;
 use std::sync::Arc;
 use thiserror::Error;
 
-pub static VNODE_OPS: VopVector = VopVector {
-    default: Some(&DEFAULT_VNODEOPS),
-    access: Some(access),
-    accessx: None,
-    getattr: Some(getattr),
-    lookup: Some(lookup),
-    open: Some(open),
-};
-
-fn access(_: &Arc<Vnode>, _: Option<&VThread>, _: Access) -> Result<(), Box<dyn Errno>> {
-    // TODO: Check how the PS4 check file permission for exfatfs.
-    Ok(())
+/// An implementation of [`crate::fs::VnodeBackend`].
+#[derive(Debug)]
+pub struct VnodeBackend {
+    file: HostFile,
 }
 
-fn getattr(vn: &Arc<Vnode>) -> Result<VnodeAttrs, Box<dyn Errno>> {
-    // Get file size.
-    let host = vn.data().downcast_ref::<HostFile>().unwrap();
-    let size = match host.len() {
-        Ok(v) => v,
-        Err(e) => return Err(Box::new(GetAttrError::GetSizeFailed(e))),
-    };
-
-    // TODO: Check how the PS4 assign file permissions for exfatfs.
-    let mode = match vn.ty() {
-        VnodeType::Directory(_) => Mode::new(0o555).unwrap(),
-        VnodeType::Character => unreachable!(), // The character device should only be in the devfs.
-    };
-
-    Ok(VnodeAttrs::new(Uid::ROOT, Gid::ROOT, mode, size))
+impl VnodeBackend {
+    pub fn new(file: HostFile) -> Self {
+        Self { file }
+    }
 }
 
-fn lookup(vn: &Arc<Vnode>, td: Option<&VThread>, name: &str) -> Result<Arc<Vnode>, Box<dyn Errno>> {
-    // Check if directory.
-    match vn.ty() {
-        VnodeType::Directory(root) => {
-            if name == ".." && *root {
-                return Err(Box::new(LookupError::DotdotOnRoot));
+impl crate::fs::VnodeBackend for VnodeBackend {
+    fn access(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        mode: Access,
+    ) -> Result<(), Box<dyn Errno>> {
+        // TODO: Check how the PS4 check file permission for exfatfs.
+        Ok(())
+    }
+
+    fn getattr(self: Arc<Self>, vn: &Arc<Vnode>) -> Result<VnodeAttrs, Box<dyn Errno>> {
+        // Get file size.
+        let size = match self.file.len() {
+            Ok(v) => v,
+            Err(e) => return Err(Box::new(GetAttrError::GetSizeFailed(e))),
+        };
+
+        // TODO: Check how the PS4 assign file permissions for exfatfs.
+        let mode = match vn.ty() {
+            VnodeType::Directory(_) => Mode::new(0o555).unwrap(),
+            VnodeType::Character => unreachable!(), // The character device should only be in the devfs.
+        };
+
+        Ok(VnodeAttrs::new(Uid::ROOT, Gid::ROOT, mode, size))
+    }
+
+    fn lookup(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        name: &str,
+    ) -> Result<Arc<Vnode>, Box<dyn Errno>> {
+        // Check if directory.
+        match vn.ty() {
+            VnodeType::Directory(root) => {
+                if name == ".." && *root {
+                    return Err(Box::new(LookupError::DotdotOnRoot));
+                }
             }
+            _ => return Err(Box::new(LookupError::NotDirectory)),
         }
-        _ => return Err(Box::new(LookupError::NotDirectory)),
-    }
 
-    // Check if directory is accessible.
-    if let Err(e) = vn.access(td, Access::EXEC) {
-        return Err(Box::new(LookupError::AccessDenied(e)));
-    }
+        // Check if directory is accessible.
+        if let Err(e) = vn.access(td, Access::EXEC) {
+            return Err(Box::new(LookupError::AccessDenied(e)));
+        }
 
-    // Check name.
-    if name == "." {
-        return Ok(vn.clone());
-    }
+        // Check name.
+        if name == "." {
+            return Ok(vn.clone());
+        }
 
-    let host = vn.data().downcast_ref::<HostFile>().unwrap();
-    let path = match name {
-        ".." => Cow::Borrowed(host.path().parent().unwrap()),
-        _ => {
-            if name.contains(|c| c == '/' || c == '\\') {
-                return Err(Box::new(LookupError::InvalidName));
+        let path = match name {
+            ".." => Cow::Borrowed(self.file.path().parent().unwrap()),
+            _ => {
+                if name.contains(|c| c == '/' || c == '\\') {
+                    return Err(Box::new(LookupError::InvalidName));
+                }
+
+                Cow::Owned(self.file.path().join(name))
             }
+        };
 
-            Cow::Owned(host.path().join(name))
-        }
-    };
+        // Get vnode.
+        let vn = match get_vnode(vn.fs(), Some(&path)) {
+            Ok(v) => v,
+            Err(e) => return Err(Box::new(LookupError::GetVnodeFailed(e))),
+        };
 
-    // Get vnode.
-    let vn = match get_vnode(vn.fs(), Some(&path)) {
-        Ok(v) => v,
-        Err(e) => return Err(Box::new(LookupError::GetVnodeFailed(e))),
-    };
+        Ok(vn)
+    }
 
-    Ok(vn)
-}
-
-fn open(
-    _: &Arc<Vnode>,
-    _: Option<&VThread>,
-    _: OpenFlags,
-    _: Option<&mut VFile>,
-) -> Result<(), Box<dyn Errno>> {
-    todo!()
+    fn open(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        mode: OpenFlags,
+        file: Option<&mut VFile>,
+    ) -> Result<(), Box<dyn Errno>> {
+        todo!()
+    }
 }
 
 /// Represents an error when [`getattr()`] was failed.

--- a/src/kernel/src/fs/vnode.rs
+++ b/src/kernel/src/fs/vnode.rs
@@ -4,6 +4,7 @@ use crate::process::VThread;
 use crate::ucred::{Gid, Uid};
 use gmtx::{Gutex, GutexGroup, GutexWriteGuard};
 use std::any::Any;
+use std::fmt::Debug;
 use std::num::NonZeroI32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -19,19 +20,17 @@ pub struct Vnode {
     fs: Arc<Mount>,                                  // v_mount
     ty: VnodeType,                                   // v_type
     tag: &'static str,                               // v_tag
-    op: &'static VopVector,                          // v_op
-    data: Arc<dyn Any + Send + Sync>,                // v_data
+    backend: Arc<dyn VnodeBackend>,                  // v_op + v_data
     item: Gutex<Option<Arc<dyn Any + Send + Sync>>>, // v_un
 }
 
 impl Vnode {
     /// See `getnewvnode` on the PS4 for a reference.
-    pub fn new(
+    pub(super) fn new(
         fs: &Arc<Mount>,
         ty: VnodeType,
         tag: &'static str,
-        op: &'static VopVector,
-        data: Arc<dyn Any + Send + Sync>,
+        backend: Arc<dyn VnodeBackend>,
     ) -> Self {
         let gg = GutexGroup::new();
 
@@ -41,8 +40,7 @@ impl Vnode {
             fs: fs.clone(),
             ty,
             tag,
-            op,
-            data,
+            backend,
             item: gg.spawn(None),
         }
     }
@@ -63,10 +61,6 @@ impl Vnode {
         matches!(self.ty, VnodeType::Character)
     }
 
-    pub fn data(&self) -> &Arc<dyn Any + Send + Sync> {
-        &self.data
-    }
-
     pub fn item(&self) -> Option<Arc<dyn Any + Send + Sync>> {
         self.item.read().clone()
     }
@@ -78,21 +72,21 @@ impl Vnode {
     pub fn access(
         self: &Arc<Vnode>,
         td: Option<&VThread>,
-        access: Access,
+        mode: Access,
     ) -> Result<(), Box<dyn Errno>> {
-        self.get_op(|v| v.access)(self, td, access)
+        self.backend.clone().access(self, td, mode)
     }
 
     pub fn accessx(
         self: &Arc<Self>,
         td: Option<&VThread>,
-        access: Access,
+        mode: Access,
     ) -> Result<(), Box<dyn Errno>> {
-        self.get_op(|v| v.accessx)(self, td, access)
+        self.backend.clone().accessx(self, td, mode)
     }
 
     pub fn getattr(self: &Arc<Self>) -> Result<VnodeAttrs, Box<dyn Errno>> {
-        self.get_op(|v| v.getattr)(self)
+        self.backend.clone().getattr(self)
     }
 
     pub fn lookup(
@@ -100,24 +94,7 @@ impl Vnode {
         td: Option<&VThread>,
         name: &str,
     ) -> Result<Arc<Self>, Box<dyn Errno>> {
-        self.get_op(|v| v.lookup)(self, td, name)
-    }
-
-    fn get_op<F>(&self, f: fn(&'static VopVector) -> Option<F>) -> F {
-        let mut vec = Some(self.op);
-
-        while let Some(v) = vec {
-            if let Some(f) = f(v) {
-                return f;
-            }
-
-            vec = v.default;
-        }
-
-        panic!(
-            "Invalid vop_vector for vnode from '{}' filesystem.",
-            self.tag
-        );
+        self.backend.clone().lookup(self, td, name)
     }
 }
 
@@ -136,24 +113,71 @@ pub enum VnodeType {
 
 /// An implementation of `vop_vector` structure.
 ///
-/// We don't support `vop_bypass` because it required the return type for all operations to be the
-/// same.
-#[derive(Debug)]
-pub struct VopVector {
-    pub default: Option<&'static Self>, // vop_default
-    pub access: Option<VopAccess>,      // vop_access
-    pub accessx: Option<VopAccessX>,    // vop_accessx
-    pub getattr: Option<VopGetAttr>,    // vop_getattr
-    pub lookup: Option<VopLookup>,      // vop_lookup
-    pub open: Option<VopOpen>,          // vop_open
-}
+/// We used slightly different mechanism here so it is idiomatic to Rust. We also don't support
+/// `vop_bypass` because it required the return type for all operations to be the same.
+///
+/// All default implementation here are the implementation of `default_vnodeops`.
+pub(super) trait VnodeBackend: Debug + Send + Sync {
+    /// An implementation of `vop_access`.
+    fn access(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        mode: Access,
+    ) -> Result<(), Box<dyn Errno>> {
+        vn.accessx(td, mode)
+    }
 
-pub type VopAccess = fn(&Arc<Vnode>, Option<&VThread>, Access) -> Result<(), Box<dyn Errno>>;
-pub type VopAccessX = fn(&Arc<Vnode>, Option<&VThread>, Access) -> Result<(), Box<dyn Errno>>;
-pub type VopGetAttr = fn(&Arc<Vnode>) -> Result<VnodeAttrs, Box<dyn Errno>>;
-pub type VopLookup = fn(&Arc<Vnode>, Option<&VThread>, &str) -> Result<Arc<Vnode>, Box<dyn Errno>>;
-pub type VopOpen =
-    fn(&Arc<Vnode>, Option<&VThread>, OpenFlags, Option<&mut VFile>) -> Result<(), Box<dyn Errno>>;
+    /// An implementation of `vop_accessx`.
+    fn accessx(
+        self: Arc<Self>,
+        vn: &Arc<Vnode>,
+        td: Option<&VThread>,
+        mode: Access,
+    ) -> Result<(), Box<dyn Errno>> {
+        let mode = match unixify_access(mode) {
+            Some(v) => v,
+            None => return Err(Box::new(DefaultError::NotPermitted)),
+        };
+
+        if mode.is_empty() {
+            return Ok(());
+        }
+
+        // This can create an infinity loop. Not sure why FreeBSD implement like this.
+        vn.access(td, mode)
+    }
+
+    /// An implementation of `vop_getattr`.
+    fn getattr(
+        self: Arc<Self>,
+        #[allow(unused_variables)] vn: &Arc<Vnode>,
+    ) -> Result<VnodeAttrs, Box<dyn Errno>> {
+        // Inline vop_bypass.
+        Err(Box::new(DefaultError::NotSupported))
+    }
+
+    /// An implementation of `vop_lookup`.
+    fn lookup(
+        self: Arc<Self>,
+        #[allow(unused_variables)] vn: &Arc<Vnode>,
+        #[allow(unused_variables)] td: Option<&VThread>,
+        #[allow(unused_variables)] name: &str,
+    ) -> Result<Arc<Vnode>, Box<dyn Errno>> {
+        Err(Box::new(DefaultError::NotDirectory))
+    }
+
+    /// An implementation of `vop_open`.
+    fn open(
+        self: Arc<Self>,
+        #[allow(unused_variables)] vn: &Arc<Vnode>,
+        #[allow(unused_variables)] td: Option<&VThread>,
+        #[allow(unused_variables)] mode: OpenFlags,
+        #[allow(unused_variables)] file: Option<&mut VFile>,
+    ) -> Result<(), Box<dyn Errno>> {
+        Ok(())
+    }
+}
 
 /// An implementation of `vattr` struct.
 pub struct VnodeAttrs {
@@ -207,30 +231,6 @@ impl Errno for DefaultError {
             Self::NotDirectory => ENOTDIR,
         }
     }
-}
-
-/// An implementation of `default_vnodeops`.
-pub static DEFAULT_VNODEOPS: VopVector = VopVector {
-    default: None,
-    access: Some(|vn, td, access| vn.accessx(td, access)),
-    accessx: Some(accessx),
-    getattr: Some(|_| Err(Box::new(DefaultError::NotSupported))), // Inline vop_bypass.
-    lookup: Some(|_, _, _| Err(Box::new(DefaultError::NotDirectory))),
-    open: Some(|_, _, _, _| Ok(())),
-};
-
-fn accessx(vn: &Arc<Vnode>, td: Option<&VThread>, access: Access) -> Result<(), Box<dyn Errno>> {
-    let access = match unixify_access(access) {
-        Some(v) => v,
-        None => return Err(Box::new(DefaultError::NotPermitted)),
-    };
-
-    if access.is_empty() {
-        return Ok(());
-    }
-
-    // This can create an infinity loop. Not sure why FreeBSD implement like this.
-    vn.access(td, access)
 }
 
 static ACTIVE: AtomicUsize = AtomicUsize::new(0); // numvnodes


### PR DESCRIPTION
So it is much more idiomatic to Rust. The benefits we got from this is we no longer need to cast `v_data` to the FS specific data.