### PR TITLE
Implement mmap names on Linux

### DIFF
--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -491,6 +491,7 @@ impl MemoryManager {
             let len = len - ((addr as usize) - (storage.addr() as usize));
 
             storage.commit(addr, len, prot)?;
+            storage.name(&name);
 
             Ok(Alloc {
                 addr,
@@ -506,6 +507,7 @@ impl MemoryManager {
             let addr = storage.addr();
 
             storage.commit(addr, len, prot)?;
+            storage.name(&name);
 
             Ok(Alloc {
                 addr,


### PR DESCRIPTION
Since Linux 5.17, mmap regions can be named. This PR makes use of that functionality.

```
$ cat /proc/PID/maps
...
7fffeb91c000-7fffeb91f000 ---p 00000000 00:00 0                          [anon:libSceSysmodule.sprx]
7fffeba00000-7fffebb28000 r-xp 00000000 00:00 0                          [anon:libSceLibcInternal.sprx]
7fffebb28000-7fffebb30000 r--p 00000000 00:00 0                          [anon:libSceLibcInternal.sprx]
7fffebb30000-7fffebb4c000 rw-p 00000000 00:00 0                          [anon:libSceLibcInternal.sprx]
7fffebb4c000-7fffebd4c000 r-xp 00000000 00:00 0                          [anon:libSceLibcInternal.sprx]
7fffebd4c000-7fffebe4c000 rw-p 00000000 00:00 0                          [anon:libSceLibcInternal.sprx]
7fffebe4c000-7fffebe4f000 ---p 00000000 00:00 0                          [anon:libSceLibcInternal.sprx]
7fffec000000-7fffec054000 r-xp 00000000 00:00 0                          [anon:libkernel.sprx]
7fffec054000-7fffec058000 r--p 00000000 00:00 0                          [anon:libkernel.sprx]
7fffec058000-7fffec090000 rw-p 00000000 00:00 0                          [anon:libkernel.sprx]
7fffec090000-7fffec290000 r-xp 00000000 00:00 0                          [anon:libkernel.sprx]
7fffec290000-7fffec390000 rw-p 00000000 00:00 0                          [anon:libkernel.sprx]
7fffec390000-7fffec393000 ---p 00000000 00:00 0                          [anon:libkernel.sprx]
7fffec400000-7fffec800000 rw-p 00000000 00:00 0                          [anon:executable]
7fffec800000-7fffec904000 r-xp 00000000 00:00 0                          [anon:executable]
7fffec904000-7fffec914000 r--p 00000000 00:00 0                          [anon:executable]
7fffec914000-7fffec918000 rw-p 00000000 00:00 0                          [anon:executable]
7fffec918000-7fffecb18000 r-xp 00000000 00:00 0                          [anon:executable]
7fffecb18000-7fffecc18000 rw-p 00000000 00:00 0                          [anon:executable]
7fffecc18000-7fffecc1b000 ---p 00000000 00:00 0                          [anon:executable]
7fffece00000-7fffece04000 ---p 00000000 00:00 0                          [anon:main stack]
7fffece04000-7fffed007000 rw-p 00000000 00:00 0                          [anon:main stack]
...

```