### PR TITLE
#603 Implement sys_nanosleep

### DIFF
--- a/src/kernel/src/time/mod.rs
+++ b/src/kernel/src/time/mod.rs
@@ -1,9 +1,11 @@
-use crate::errno::Errno;
+use crate::errno::{Errno, EINVAL};
+use crate::info;
 use crate::syscalls::{SysErr, SysIn, SysOut, Syscalls};
+use std::io::Error;
+use std::mem::zeroed;
 use std::num::NonZeroI32;
 use std::sync::Arc;
 use thiserror::Error;
-
 pub struct TimeManager {}
 
 impl TimeManager {
@@ -12,6 +14,7 @@ impl TimeManager {
 
         sys.register(116, &time, Self::sys_gettimeofday);
         sys.register(232, &time, Self::sys_clock_gettime);
+        sys.register(240, &time, Self::sys_nanosleep);
 
         time
     }
@@ -37,6 +40,30 @@ impl TimeManager {
         let clock: i32 = i.args[0].try_into().unwrap();
 
         todo!("clock_gettime with clock = {clock}")
+    }
+
+    fn sys_nanosleep(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
+        let req: *const Timespec = i.args[0].try_into().unwrap();
+        let rem: *mut Timespec = i.args[1].try_into().unwrap();
+
+        let sleep = unsafe { &*req };
+
+        info!("sys_nanosleep({:#?}, {:?})", sleep, rem);
+
+        if sleep.seconds < 0 || sleep.nanoseconds < 0 || sleep.nanoseconds > 999999999 {
+            return Err(SysErr::Raw(EINVAL));
+        }
+
+        if !rem.is_null() {
+            unsafe { *rem = zeroed() }
+        }
+
+        match Timespec::raw_nanosleep(sleep) {
+            Err(error) => Err(SysErr::Raw(unsafe {
+                NonZeroI32::new_unchecked(error.raw_os_error().unwrap())
+            })),
+            Ok(_) => Ok(0.into()),
+        }
     }
 }
 
@@ -104,6 +131,98 @@ impl From<libc::timeval> for TimeVal {
         Self {
             sec: tv.tv_sec,
             usec: tv.tv_usec as i64, // The cast is here because of MacOS
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Timespec {
+    pub seconds: i64,     // tv_sec
+    pub nanoseconds: i64, // tv_nsec
+}
+
+impl Timespec {
+    #[cfg(unix)]
+    fn raw_nanosleep(ts: &Timespec) -> Result<std::ffi::c_int, Error> {
+        let mut req = ::libc::timespec {
+            tv_sec: ts.seconds,
+            tv_nsec: ts.nanoseconds,
+        };
+
+        let mut rem = unsafe { zeroed() };
+
+        loop {
+            let ret = unsafe { ::libc::nanosleep(&req, &mut rem) };
+
+            if ret == 0 {
+                return Ok(0.into());
+            }
+
+            if Error::last_os_error().raw_os_error().unwrap() == ::libc::EINTR {
+                req = rem;
+                rem = unsafe { zeroed() }
+            } else {
+                return Err(Error::last_os_error());
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    fn raw_nanosleep(ts: &Timespec) -> Result<std::ffi::c_int, Error> {
+        use std::os::raw::c_void;
+        use std::sync::{Arc, Condvar, Mutex};
+        use windows_sys::Win32::Foundation::{BOOLEAN, HANDLE};
+        use windows_sys::Win32::System::Threading::{CreateTimerQueueTimer, WT_EXECUTEONLYONCE};
+
+        pub type Timer = HANDLE;
+
+        let pair: Arc<(Mutex<bool>, Condvar)> = Arc::new((Mutex::new(false), Condvar::new()));
+        let pair2 = pair.clone();
+
+        unsafe extern "system" fn callback(arg: *mut ::core::ffi::c_void, _: BOOLEAN) {
+            let pair2: Arc<(Mutex<bool>, Condvar)> = Arc::from_raw(arg as _);
+            let (lock, cvar) = &*pair2;
+            let mut triggered = lock.lock().unwrap();
+            *triggered = true;
+            cvar.notify_one();
+        }
+
+        let milliseconds = ts.seconds * 1000 + ts.nanoseconds / 1000000;
+
+        let mut timerhandle = HANDLE::default();
+        let ret = unsafe {
+            CreateTimerQueueTimer(
+                &mut timerhandle,
+                0,
+                Some(callback),
+                Arc::into_raw(pair2) as *const c_void,
+                milliseconds as u32,
+                0,
+                WT_EXECUTEONLYONCE,
+            )
+        };
+
+        let (lock, cvar) = &*pair;
+        let mut triggered = lock.lock().unwrap();
+        while !*triggered {
+            triggered = cvar.wait(triggered).unwrap();
+        }
+
+        if ret > 0 {
+            return Ok(0.into());
+        } else {
+            return Err(Error::last_os_error());
+        }
+    }
+}
+
+#[cfg(unix)]
+impl From<libc::timespec> for Timespec {
+    fn from(ts: libc::timespec) -> Self {
+        Self {
+            seconds: ts.tv_sec,
+            nanoseconds: ts.tv_nsec,
         }
     }
 }


### PR DESCRIPTION
I've included the Windows implementation, but I have no idea what am I doing there so there might be bugs.

This is not 100% correct with PS4, as it will always sleep the requested amount on both Windows and Linux - that should not be a problem though as libkernel functions would have restarted on EINTR anyway