### PR TITLE
Handle missing app version

### DIFF
--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -129,7 +129,12 @@ fn start() -> Result<(), KernelError> {
     writeln!(log, "Application Title   : {}", param.title().unwrap()).unwrap();
     writeln!(log, "Application ID      : {}", param.title_id()).unwrap();
     writeln!(log, "Application Category: {}", param.category()).unwrap();
-    writeln!(log, "Application Version : {}", param.app_ver().unwrap()).unwrap();
+    writeln!(
+        log,
+        "Application Version : {}",
+        param.app_ver().unwrap_or("UNKNOWN")
+    )
+    .unwrap();
 
     // Hardware information
     writeln!(


### PR DESCRIPTION
I've found some homebrew that was missing app_version and crashing on that unwrap()