### PR TITLE
Replaces logic error with a todo on NullFS

### DIFF
--- a/src/kernel/src/fs/null/vnode.rs
+++ b/src/kernel/src/fs/null/vnode.rs
@@ -153,6 +153,5 @@ impl Errno for OpenError {
 
 /// See `null_nodeget` on the PS4 for a reference.
 pub(super) fn null_nodeget(mnt: &Arc<Mount>, lower: Arc<Vnode>) -> Arc<Vnode> {
-    // TODO: consider implement the hash table for caching.
-    Vnode::new(mnt, lower.ty().clone(), "null", VnodeBackend { lower })
+    todo!()
 }


### PR DESCRIPTION
The reason is because each vnode must represent only one file/directory. So it is a logic error to have multiple vnode represents a single lower vnode.