### PR TITLE
Increase executable memory segment size

### DIFF
--- a/src/kernel/src/rtld/mem.rs
+++ b/src/kernel/src/rtld/mem.rs
@@ -122,7 +122,7 @@ impl Memory {
         let obcode = segments.len();
         let segment = MemorySegment {
             start: len,
-            len: (1024 * 1024) * 2,
+            len: (1024 * 1024) * 4,
             program: None,
             prot: Protections::CPU_READ | Protections::CPU_EXEC,
         };


### PR DESCRIPTION
Bloodborne fails to load with 2MB of memory available, 4MB seem to be enough (for now).