### PR TITLE
Do not crash on tid == -1 in sys_thr_set_name

### DIFF
--- a/src/kernel/src/process/mod.rs
+++ b/src/kernel/src/process/mod.rs
@@ -421,7 +421,7 @@ impl VProc {
     }
 
     fn sys_thr_set_name(self: &Arc<Self>, i: &SysIn) -> Result<SysOut, SysErr> {
-        let tid: i32 = i.args[0].try_into().unwrap();
+        let tid: i64 = i.args[0].into();
         let name: Option<&str> = unsafe { i.args[1].to_str(32) }?;
 
         if tid == -1 {
@@ -433,7 +433,7 @@ impl VProc {
 
             let thr = threads
                 .iter()
-                .find(|t| t.id().get() == tid)
+                .find(|t| t.id().get() == tid as i32)
                 .ok_or(SysErr::Raw(ESRCH))?;
 
             info!(


### PR DESCRIPTION
Previous implementation thought of tid == -1 but it crashed on unwrapping the conversion to i32. This is called by system app ShellAppProxy