### PR TITLE
Changes GITHUB_TOKEN from Bearer to token

### DIFF
--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -30,7 +30,7 @@ jobs:
             info = artifact
 
         req = Request(info.archive_download_url, None, {
-          "Authorization": f"Bearer {tok}",
+          "Authorization": f"token {tok}",
           "Accept": "application/vnd.github+json"
         })
 


### PR DESCRIPTION
Just take a look on PyGithub source and found out they use `token` instead of `Bearer`. The problem is GitHub docs does not mentioned about this.