### PR TITLE
Kernel backtrace in GUI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,9 @@ add_executable(obliteration WIN32 MACOSX_BUNDLE
     settings.cpp
     system.cpp
     system_downloader.cpp
-    update_firmware.cpp)
+    update_firmware.cpp
+    debugger.cpp
+    symbol_resolver.cpp)
 
 if(WIN32)
     target_sources(obliteration PRIVATE resources.rc)
@@ -107,6 +109,9 @@ target_compile_features(obliteration PRIVATE cxx_std_17)
 target_link_libraries(obliteration PRIVATE Qt6::Widgets)
 target_link_libraries(obliteration PRIVATE Threads::Threads)
 target_link_libraries(obliteration PRIVATE ${LIBCORE})
+if(LINUX)
+    target_link_libraries(obliteration PRIVATE unwind unwind-ptrace unwind-x86_64)
+endif()
 
 if(WIN32)
     target_link_libraries(obliteration PRIVATE bcrypt imm32 ntdll setupapi userenv version winmm ws2_32)

--- a/src/debugger.cpp
+++ b/src/debugger.cpp
@@ -1,0 +1,293 @@
+#include "debugger.h"
+#include "symbol_resolver.h"
+
+#ifdef __linux__
+#include <QDebug>
+#include <QFile>
+#include <QRegularExpression>
+#include <QThread>
+
+#include <libunwind.h>
+#include <libunwind-ptrace.h>
+#include <string.h>
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#endif
+
+Debugger::Debugger(QProcess* kernel, SymbolResolver* resolver): m_kernel(kernel), t(nullptr), m_symbol_resolver(resolver)
+{
+    qDebug() << "starting debugger";
+#ifdef __linux__
+
+    t = QThread::create([this](){
+        int pid = this->m_kernel->processId();
+        auto seize = ptrace(PTRACE_SEIZE, pid, 0, PTRACE_O_TRACEEXIT | PTRACE_O_TRACECLONE | PTRACE_O_TRACEVFORKDONE | PTRACE_O_EXITKILL);
+        if (seize == -1)
+        {
+            qDebug() << "PTRACE_SEIZE failed with " << strerror(errno);
+            return;
+        }
+
+        int status, ret;
+
+        while (ret = waitpid(-1, &status, __WALL), ret != -1)
+        {
+            if (WIFSTOPPED(status))
+            {
+                qDebug() << "PID" << ret << "stopped with signal" << WSTOPSIG(status);
+                if (status>>8 == (SIGTRAP | (PTRACE_EVENT_EXIT<<8)))
+                {
+                    // kernel crashed, now we can probe why
+                    unsigned long msg;
+                    if (-1 == ptrace(PTRACE_GETEVENTMSG, ret, 0, &msg))
+                    {
+                        qDebug() << "PTRACE_GETEVENTMSG failed" << strerror(errno);
+                    }
+                    else
+                    {
+                        qDebug() << "kernel exit status" << msg;
+                    }
+
+                    emit this->kernelCrash();
+                    return;
+                }
+                else if (status>>8 == (SIGTRAP | (PTRACE_EVENT_CLONE<<8)))
+                {
+                    // new thread created by kernel
+                    unsigned long msg;
+                    if (-1 == ptrace(PTRACE_GETEVENTMSG, ret, 0, &msg))
+                    {
+                        qDebug() << "PTRACE_GETEVENTMSG failed" << strerror(errno);
+                    }
+                    else
+                    {
+                        qDebug() << "new thread id" << msg;
+                    }
+                    if (-1 == ptrace(PTRACE_CONT, ret, 0, 0))
+                    {
+                        qDebug() << "PTRACE_CONT failed" << ret << strerror(errno);
+                    }
+                    continue;
+                }
+                else if (status>>8 == (SIGTRAP | (PTRACE_EVENT_VFORK_DONE<<8)))
+                {
+                    // kernel vfork
+                    unsigned long msg;
+                    if (-1 == ptrace(PTRACE_GETEVENTMSG, ret, 0, &msg))
+                    {
+                        qDebug() << "PTRACE_GETEVENTMSG failed" << strerror(errno);
+                    }
+                    else
+                    {
+                        qDebug() << "kernel vfork" << msg;
+                    }
+                    if (-1 == ptrace(PTRACE_CONT, ret, 0, 0))
+                    {
+                        qDebug() << "PTRACE_CONT failed" << strerror(errno);
+                    }
+                    continue;
+                }
+                else if (WSTOPSIG(status) == SIGSEGV)
+                {
+                    this->printBacktrace(pid, ret);
+                    emit this->kernelCrash();
+                    for (;;)
+                    {
+                        if (QThread::currentThread()->isInterruptionRequested())
+                        {
+                            qDebug() << "detaching from kernel";
+                            if (-1 == ptrace(PTRACE_DETACH, pid, 0, 0))
+                                qDebug() << "PTRACE_DETACH failed with" << strerror(errno);
+                            return;
+                        }
+                    }
+                }
+                if (-1 == ptrace(PTRACE_CONT, ret, 0, WSTOPSIG(status)))
+                {
+                    qDebug() << "PTRACE_CONT failed" << strerror(errno);
+                }
+            }
+        }
+        qDebug() << "waitpid failed with" << strerror(errno);
+        qDebug() << "thread exited";
+    });
+
+    t->start();
+
+#endif
+}
+
+struct memory_mapping
+{
+    unsigned long start_addr;
+    unsigned long end_addr;
+    char permissions;
+    std::string name_or_file;
+};
+
+struct process_memory_map
+{
+    std::vector<memory_mapping> maps;
+
+    std::optional<std::pair<std::string, uint64_t>> find_area(uint64_t addr);
+};
+
+std::optional<std::pair<std::string, uint64_t>> process_memory_map::find_area(uint64_t addr)
+{
+    for (auto &&map : this->maps)
+    {
+        if (addr >= map.start_addr && addr <= map.end_addr)
+        {
+            auto offset = addr - map.start_addr;
+
+            return {{map.name_or_file, offset}};
+        }
+    }
+
+    return {};
+}
+
+std::optional<process_memory_map> read_memory_map(int pid);
+
+void Debugger::printBacktrace(int pid, int tid)
+{
+#ifdef __linux__
+    auto upt = _UPT_create(tid);
+    auto addr_space = unw_create_addr_space(&_UPT_accessors, 0);
+
+    auto memory_map = read_memory_map(pid);
+
+    unw_cursor_t c;
+    int ret = unw_init_remote(&c, addr_space, upt);
+    if (ret != 0)
+    {
+        qDebug() << "unw_init_remote failed with" << ret;
+        return;
+    }
+
+    user_regs_struct regs;
+    if (-1 == ptrace(PTRACE_GETREGS, tid, 0, &regs))
+    {
+        qDebug() << "couldn't read registers from tid" << tid << "(" << strerror(errno) << ")";
+    }
+    else
+    {
+        qDebug() << "Thread" << tid << "registers:";
+        qDebug() << Qt::hex << Qt::showbase << "rax:" << regs.rax << "    " << "r8: "    << regs.r8;
+        qDebug() << Qt::hex << Qt::showbase << "rbx:" << regs.rbx << "    " << "r9: "    << regs.r9;
+        qDebug() << Qt::hex << Qt::showbase << "rcx:" << regs.rcx << "    " << "r10:"    << regs.r10;
+        qDebug() << Qt::hex << Qt::showbase << "rdx:" << regs.rdx << "    " << "r11:"    << regs.r11;
+        qDebug() << Qt::hex << Qt::showbase << "rsi:" << regs.rsi << "    " << "r12:"    << regs.r12;
+        qDebug() << Qt::hex << Qt::showbase << "rdi:" << regs.rdi << "    " << "r13:"    << regs.r13;
+        qDebug() << Qt::hex << Qt::showbase << "rbp:" << regs.rbp << "    " << "r14:"    << regs.r14;
+        qDebug() << Qt::hex << Qt::showbase << "rsp:" << regs.rsp << "    " << "r15:"    << regs.r15;
+        qDebug() << Qt::hex << Qt::showbase << "fs: " << regs.fs  << "    " << "rip:"    << regs.rip;
+        qDebug() << Qt::hex << Qt::showbase << "gs: " << regs.gs  << "    " << "eflags:" << regs.eflags;
+    }
+
+    do {
+        unw_word_t  offset, pc;
+        char        fname[64];
+
+        unw_get_reg(&c, UNW_REG_IP, &pc);
+
+        auto f = memory_map->find_area(pc);
+
+        fname[0] = '\0';
+        (void) unw_get_proc_name(&c, fname, sizeof(fname), &offset);
+        auto demangled = fname[0] ? SymbolResolver::demangle(std::string(fname)) : "";
+
+        if (f)
+        {
+            auto ps4symbol = m_symbol_resolver->resolve(QString::fromStdString((*f).first), (*f).second).value_or(std::make_pair(QString(), (*f).second));
+            printf("\n%p : (%s+0x%x) [%p] [%s+0x%lx]", (void *)pc,
+                   fname[0] ? demangled.c_str() : ps4symbol.first.toUtf8().data(),
+                   fname[0] ? (int) offset : ps4symbol.second,
+                   (void *) pc,
+                   (*f).first.c_str(),
+                   (*f).second);
+        }
+        else
+        {
+            printf("\n%p : (%s+0x%x) [%p]", (void *)pc,
+                   fname,
+                   (int) offset,
+                   (void *) pc);
+        }
+    } while (unw_step(&c) > 0);
+
+    _UPT_destroy(upt);
+#endif
+}
+
+void Debugger::detach()
+{
+    if (t)
+    {
+        t->requestInterruption();
+    }
+}
+
+const static auto whitespace = QRegularExpression("\\s+");
+const static auto minus = QRegularExpression("-");
+
+std::optional<process_memory_map> read_memory_map(int pid)
+{
+    QFile maps(("/proc/" + std::to_string(pid) + "/maps").c_str());
+
+    if (!maps.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        qDebug() << maps.error();
+        return {};
+    }
+
+    std::vector<memory_mapping> ret;
+
+    QTextStream in(&maps);
+    while(1)
+    {
+        auto line = in.readLine();
+        if (line.isNull())
+            break;
+
+        auto list = line.split(whitespace, Qt::SkipEmptyParts);
+
+        auto addresses = list.at(0).split(minus);
+        auto start_addr = addresses.at(0).toULong(nullptr, 16);
+        auto end_addr = addresses.at(1).toULong(nullptr, 16);
+
+        auto permissions = list.at(1);
+        char prot = 0;
+        for (auto &&a : permissions)
+        {
+            if (a == 'r')
+                prot |= 4;
+            if (a == 'w')
+                prot |= 2;
+            if (a == 'x')
+                prot |= 1;
+        }
+
+        QString name_or_file = "";
+        if (6 == list.count())
+            name_or_file = list.at(5);
+
+        ret.push_back({
+            start_addr,
+            end_addr,
+            prot,
+            name_or_file.replace("[anon:", "").replace("]", "").replace("[", "").toStdString()
+        });
+    }
+
+    return process_memory_map{ret};
+}
+
+Debugger::~Debugger()
+{
+    if (t)
+        t->deleteLater();
+}
+
+

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -1,0 +1,30 @@
+#ifndef DEBUGGER_H
+#define DEBUGGER_H
+
+#include <QProcess>
+
+#include "symbol_resolver.h"
+
+class QThread;
+class SymbolResolver;
+
+class Debugger: public QObject
+{
+    Q_OBJECT
+public:
+    Debugger(QProcess* kernel, SymbolResolver* resolver);
+    ~Debugger();
+
+    void detach();
+
+signals:
+    void kernelCrash();
+
+private:
+    void printBacktrace(int pid, int tid);
+    QProcess *m_kernel;
+    QThread *t;
+    SymbolResolver* m_symbol_resolver;
+};
+
+#endif // DEBUGGER_H

--- a/src/main_window.hpp
+++ b/src/main_window.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QModelIndex>
 #include <QProcess>
 
+class Debugger;
 class LogFormatter;
 class QListView;
+class SymbolResolver;
 
 class MainWindow final : public QMainWindow {
 public:
@@ -21,17 +24,21 @@ protected:
 private slots:
     void tabChanged();
     void installPkg();
+    void restartGame();
     void openSystemFolder();
     void reportIssue();
     void aboutObliteration();
     void requestGamesContextMenu(const QPoint &pos);
     void startGame(const QModelIndex &index);
+    void kernelCrashed();
     void kernelError(QProcess::ProcessError error);
     void kernelOutput();
+    void kernelStarted();
     void kernelTerminated(int exitCode, QProcess::ExitStatus exitStatus);
 
 private:
     bool loadGame(const QString &gameId);
+    void setLastGame(const QModelIndex &index);
     void killKernel();
     void restoreGeometry();
     bool requireEmulatorStopped();
@@ -39,6 +46,10 @@ private:
 private:
     QTabWidget *m_tab;
     QListView *m_games;
+    QAction *m_restart_game;
+    QModelIndex m_last_index;
     LogFormatter *m_log;
     QProcess *m_kernel;
+    Debugger *m_debugger;
+    SymbolResolver* m_symbol_resolver;
 };

--- a/src/symbol_resolver.cpp
+++ b/src/symbol_resolver.cpp
@@ -1,0 +1,188 @@
+#include "symbol_resolver.h"
+
+#include <QDirIterator>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QRegularExpression>
+#include <QString>
+
+SymbolResolver::SymbolResolver(QDir orbisPs4ToolchainDir, QDir ps4LibDocPath, QDir ps4systemDir) :
+    orbisPs4ToolchainDir(orbisPs4ToolchainDir), ps4LibDocPath(ps4LibDocPath), ps4systemDir(ps4systemDir)
+{
+    auto ps4Toolchain = qEnvironmentVariable("OO_PS4_TOOLCHAIN");
+    if (!ps4Toolchain.isNull())
+        this->orbisPs4ToolchainDir = QDir(ps4Toolchain);
+
+    auto ps4LibDoc = qEnvironmentVariable("PS4LIBDOC");
+    if (!ps4LibDoc.isNull())
+        this->ps4LibDocPath = QDir(ps4LibDoc);
+}
+
+void SymbolResolver::setGameDir(const QString &gameDir)
+{
+    this->gameDir = QDir(gameDir);
+}
+
+std::optional<QString> SymbolResolver::locate_lib(const QString& searchPath, const QString &library, bool searchElf)
+{
+    auto searchDir = searchPath;
+    if (searchElf && (library.startsWith("libSceFios2")
+                      || library.startsWith("libc")))
+    //  || library.startsWith("") TODO: other libraries provided with the app?
+    {
+        searchDir = this->gameDir.absoluteFilePath("sce_module");
+    }
+
+    QDirIterator it(searchDir, QDir::Files, QDirIterator::Subdirectories);
+
+    while (it.hasNext())
+    {
+        auto file = it.nextFileInfo();
+
+        if (file.fileName().compare(library) == 0)
+            return {file.absoluteFilePath()};
+    }
+
+    return {};
+}
+
+std::vector<std::pair<uint64_t, nid>> SymbolResolver::read_nids(const QString& library)
+{
+    auto cached = this->symbols_cache.find(library);
+    if (cached != std::end(this->symbols_cache))
+        return cached.value();
+
+    auto path = locate_lib(ps4systemDir.absoluteFilePath("system"), library);
+    if (!path)
+        return {};
+
+    auto readoelf = this->orbisPs4ToolchainDir.absoluteFilePath("bin/linux/readoelf");
+    QProcess p;
+    p.start(readoelf, {"-s", *path});
+
+    const static auto whitespace = QRegularExpression("\\s+");
+
+    std::vector<std::pair<uint64_t, nid>> ret;
+
+    if (p.waitForFinished(1500) && p.exitCode() == 0)
+    {
+        p.readLine(); // Symbol table...
+        p.readLine(); // column names
+
+        QString line;
+        bool ok;
+
+        while (line = p.readLine(), !line.isNull())
+        {
+            auto info = line.split(whitespace, Qt::SkipEmptyParts);
+
+            if (info.isEmpty())
+                continue;
+
+            auto offset = info.at(1).toULongLong(&ok, 16);
+            if (offset == 0 || !ok)
+                continue;
+
+            auto name = info.at(7);
+
+            ret.emplace_back(offset, name);
+        }
+
+        std::sort(std::begin(ret), std::end(ret), [](const std::pair<uint64_t, nid>& p1, const std::pair<uint64_t, nid>& p2){
+            return p1.first < p2.first;
+        });
+        this->symbols_cache.insert(library, ret);
+
+        return ret;
+    }
+    else
+    {
+        qDebug() << readoelf << *path << p.exitCode();
+        qDebug() << "reading nids from" << library << "failed";
+        return {};
+    }
+}
+
+QString SymbolResolver::resolve_nid(const QString& library, const nid& nid)
+{
+    auto cached = this->nid_cache.find(nid);
+    if (cached != std::end(this->nid_cache))
+        return cached.value();
+
+    auto sprxLibrary = QString(library).replace(QString(".prx"), QString(".sprx"));
+    auto jsonPath = locate_lib(ps4LibDocPath.absoluteFilePath("system"), sprxLibrary + ".json", false);
+    if (!jsonPath)
+        return nid;
+
+    QFile file(*jsonPath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return nid;
+
+    auto doc = QJsonDocument::fromJson(file.readAll());
+    if (doc.isNull())
+        return nid;
+
+    auto modules = doc.object().value("modules").toArray();
+    for (auto &&module : modules)
+    {
+        auto object = module.toObject();
+        if (library.startsWith(object.value("name").toString()))
+        {
+            auto libraries = object.value("libraries").toArray();
+            for (auto &&library : libraries)
+            {
+                auto object = library.toObject();
+                if (!object.value("is_export").toBool(false))
+                    continue;
+
+                for (auto &&symbol : object.value("symbols").toArray())
+                {
+                    auto object = symbol.toObject();
+
+                    if (nid.startsWith(object.value("encoded_id").toString()))
+                    {
+                        auto name = object.value("name").toString();
+                        this->nid_cache.insert(nid, name);
+
+                        return name;
+                    }
+                }
+            }
+        }
+    }
+
+    return nid;
+}
+
+std::optional<std::pair<QString, uint64_t>> SymbolResolver::resolve(const QString &library, uint64_t offset)
+{
+    auto symbols = read_nids(library);
+    auto last = std::cend(symbols);
+
+    auto subsequentSymbol = std::lower_bound(std::cbegin(symbols), last, offset, [](const std::pair<uint64_t, nid>& p1, const uint64_t& p2){
+        return p1.first < p2;
+    });
+
+    if (subsequentSymbol == last || subsequentSymbol == std::cbegin(symbols))
+        return {};
+
+    auto funNid = std::prev(subsequentSymbol);
+    auto funName = resolve_nid(library, (*funNid).second);
+
+    return {{funName, offset - (*funNid).first}};
+}
+
+std::string SymbolResolver::demangle(const std::string &symbol)
+{
+    QProcess p;
+    p.start(QString("c++filt"), {QString::fromStdString(symbol)});
+
+    if (p.waitForFinished(1000) && p.exitCode() == 0)
+    {
+        return p.readLine().trimmed().toStdString();
+    }
+
+    return symbol;
+}

--- a/src/symbol_resolver.h
+++ b/src/symbol_resolver.h
@@ -1,0 +1,38 @@
+#ifndef SYMBOLRESOLVER_H
+#define SYMBOLRESOLVER_H
+
+#include <optional>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include <QDir>
+#include <QMap>
+#include <QString>
+
+typedef QString nid;
+
+class SymbolResolver
+{
+    QMap<QString, std::vector<std::pair<uint64_t, nid>>> symbols_cache;
+    QMap<nid, QString> nid_cache;
+
+    QDir orbisPs4ToolchainDir;
+    QDir ps4LibDocPath;
+
+    QDir ps4systemDir;
+    QDir gameDir;
+
+    std::optional<QString> locate_lib(const QString& searchPath, const QString& library, bool searchElf = true);
+    std::vector<std::pair<uint64_t, nid>> read_nids(const QString& library);
+    QString resolve_nid(const QString& library, const nid& nid);
+
+public:
+    SymbolResolver(QDir orbisPs4ToolchainDir, QDir ps4LibDocPath, QDir ps4systemDir);
+    std::optional<std::pair<QString, uint64_t>> resolve(const QString &library, uint64_t offset);
+    void setGameDir(const QString& gameDir);
+
+    static std::string demangle(const std::string& symbol);
+};
+
+#endif // SYMBOLRESOLVER_H


### PR DESCRIPTION
That's what will be printed to application output when obkrnl crashes on Linux:

```
PID 280231 stopped with signal 11
Thread 280231 registers:
rax: 0x0      r8:  0x3e0
rbx: 0x7c1eafe01590      r9:  0x0
rcx: 0x28      r10: 0x0
rdx: 0xc0288001      r11: 0x293
rsi: 0x7c1eafdffc44      r12: 0x4000
rdi: 0x7c1eafdffa7c      r13: 0x800000
rbp: 0x7c1eafe015f0      r14: 0x0
rsp: 0x7c1eafdff9f0      r15: 0x0
fs:  0x0      rip: 0x58693693fe1c
gs:  0x0      eflags: 0x10202

0x58693693fe1c : (obkrnl::dmem::DmemManager::dmem_ioctl::h8e733190dbec8e96+0x67c) [0x58693693fe1c] [,,,/obliteration/src/target/debug/obkrnl+0xa8e1c]
0x5869368cfdea : (obkrnl::fs::dev::vnode::ioctl::hf6e09a2b33579580+0x20a) [0x5869368cfdea] [,,,/obliteration/src/target/debug/obkrnl+0x38dea]
0x5869368f6409 : (obkrnl::fs::vnode::Vnode::ioctl::hc4fbe306b6e2be81+0x79) [0x5869368f6409] [,,,/obliteration/src/target/debug/obkrnl+0x5f409]
0x5869369cfad2 : (_ZN6obkrnl2fs4file16DEFAULT_VFILEOPS28_$u7b$$u7b$closure$u7d$$u+0x61) [0x5869369cfad2] [,,,/obliteration/src/target/debug/obkrnl+0x138ad2]
0x7c1e9dc17801 : (sceKernelAllocateDirectMemory+0x71) [0x7c1e9dc17801] [libkernel.sprx+0x17801]
0x7c1ea1e32111 : (+0x1a32111) [0x7c1ea1e32111] [executable+0x1a32111]
0x7c1ea1e3eecb : (+0x1a3eecb) [0x7c1ea1e3eecb] [executable+0x1a3eecb]
0x7c1ea1e331b9 : (+0x1a331b9) [0x7c1ea1e331b9] [executable+0x1a331b9]
0x7c1e94820545 : (_malloc_init+0x2a5) [0x7c1e94820545] [libc.prx+0x20545]
0x7c1e948005b9 : (_Touptab+0x461) [0x7c1e948005b9] [libc.prx+0x5b9]
0x7c1e9480004b : (+0x4b) [0x7c1e9480004b] [libc.prx+0x4b]
0x7c1e9dc2c1eb : (sceKernelLoadStartModule+0x61b) [0x7c1e9dc2c1eb] [libkernel.sprx+0x2c1eb]
0x7c1e96e016ca : (+0x16ca) [0x7c1e96e016ca] [libSceSysmodule.sprx+0x16ca]
0x7c1e96e02e5b : (+0x2e5b) [0x7c1e96e02e5b] [libSceSysmodule.sprx+0x2e5b]
0x7c1e9dc2a501 : (sceKernelIsAddressSanitizerEnabled+0xc81) [0x7c1e9dc2a501] [libkernel.sprx+0x2a501]
```