### PR TITLE
Refactors seekable check

### DIFF
--- a/src/kernel/src/fs/file.rs
+++ b/src/kernel/src/fs/file.rs
@@ -16,9 +16,8 @@ use thiserror::Error;
 /// An implementation of `file` structure.
 #[derive(Debug)]
 pub struct VFile {
-    ty: VFileType,             // f_type
-    flags: VFileFlags,         // f_flag
-    vnode: Option<Arc<Vnode>>, // f_vnode
+    ty: VFileType,     // f_type
+    flags: VFileFlags, // f_flag
 }
 
 impl VFile {
@@ -26,7 +25,6 @@ impl VFile {
         Self {
             ty,
             flags: VFileFlags::empty(),
-            vnode: None,
         }
     }
 
@@ -39,9 +37,13 @@ impl VFile {
     }
 
     /// Checking if this returns `Some` is equivalent to when FreeBSD and the PS4 check
-    /// fp->f_ops->fo_flags & DFLAG_PASSABLE != 0, therefore we use this instead.
-    pub fn vnode(&self) -> Option<&Arc<Vnode>> {
-        self.vnode.as_ref()
+    /// fp->f_ops->fo_flags & DFLAG_SEEKABLE != 0, therefore we use this instead.
+    pub fn seekable_vnode(&self) -> Option<&Arc<Vnode>> {
+        match &self.ty {
+            VFileType::Vnode(vn) => Some(vn),
+            VFileType::Device(_) => todo!(),
+            _ => None,
+        }
     }
 
     /// See `dofileread` on the PS4 for a reference.

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -655,7 +655,7 @@ impl Fs {
     fn preadv(&self, fd: i32, uio: UioMut, offset: i64, td: &VThread) -> Result<SysOut, SysErr> {
         let file = td.proc().files().get_for_read(fd)?;
 
-        let vnode = file.vnode().ok_or(SysErr::Raw(ESPIPE))?;
+        let vnode = file.seekable_vnode().ok_or(SysErr::Raw(ESPIPE))?;
 
         if offset < 0 && !vnode.is_character() {
             return Err(SysErr::Raw(EINVAL));
@@ -680,7 +680,7 @@ impl Fs {
     fn pwritev(&self, fd: i32, uio: Uio, offset: i64, td: &VThread) -> Result<SysOut, SysErr> {
         let file = td.proc().files().get_for_write(fd)?;
 
-        let vnode = file.vnode().ok_or(SysErr::Raw(ESPIPE))?;
+        let vnode = file.seekable_vnode().ok_or(SysErr::Raw(ESPIPE))?;
 
         if offset < 0 && !vnode.is_character() {
             return Err(SysErr::Raw(EINVAL));
@@ -748,7 +748,7 @@ impl Fs {
 
         let file = td.proc().files().get(fd)?;
 
-        let vnode = file.vnode().ok_or(SysErr::Raw(ESPIPE))?;
+        let vnode = file.seekable_vnode().ok_or(SysErr::Raw(ESPIPE))?;
 
         // check vnode type
 


### PR DESCRIPTION
I realized that other file types store a vnode too, but only device and vnode types are seekable.