### PR TITLE
Add path specification for Windows Root

### DIFF
--- a/src/kernel/src/fs/host/file.rs
+++ b/src/kernel/src/fs/host/file.rs
@@ -49,9 +49,8 @@ impl HostFile {
         use windows_sys::Win32::System::Kernel::OBJ_CASE_INSENSITIVE;
 
         // Encode path name.
-        let mut path_spec = String::from("\\??\\");
-        path_spec.push_str(path.as_ref().to_str().unwrap());
-        let path = std::path::Path::new(&path_spec);
+        let path_spec = format!("\\??\\{}", path.as_ref().to_str().unwrap());
+        let path = std::path::PathBuf::from(path_spec);
         let mut path: Vec<u16> = path.as_os_str().encode_wide().collect();
         let len: u16 = (path.len() * 2).try_into().unwrap();
         let mut path = UNICODE_STRING {

--- a/src/kernel/src/fs/host/file.rs
+++ b/src/kernel/src/fs/host/file.rs
@@ -49,7 +49,9 @@ impl HostFile {
         use windows_sys::Win32::System::Kernel::OBJ_CASE_INSENSITIVE;
 
         // Encode path name.
-        let path = path.as_ref();
+        let mut path_spec = String::from("\\??\\");
+        path_spec.push_str(path.as_ref().to_str().unwrap());
+        let path = std::path::Path::new(&path_spec);
         let mut path: Vec<u16> = path.as_os_str().encode_wide().collect();
         let len: u16 = (path.len() * 2).try_into().unwrap();
         let mut path = UNICODE_STRING {


### PR DESCRIPTION
The simplest solution I could think of is solving this internally instead of users having to reconfigure their registry or .kernel-debug file.

Fixes the Root function for windows by using the `\??\` specification for the drive path. `\\??\\` due to how Rust handles backspaces.

We now reach the todo for raw_mkdir for Windows.