### PR TITLE
Moves to clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+CompileFlags:
+  Remove:
+  - -mno-direct-extern-access

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+/.cache/
 /.flatpak-builder/
 /.kernel-debug
 /build/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,10 @@
   "configurePresets": [
     {
       "name": "default",
-      "binaryDir": "${sourceDir}/build"
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+      }
     },
     {
       "name": "windows",

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Obliteration supports only 4KB/8KB/16KB pages. Most people should not have any p
 
 ### Install Qt 6
 
-You need to install Qt 6 on your system before you proceed. The minimum version is 6.5.
+You need to install Qt 6 on your system before you proceed. The minimum version is 6.5. You also need to enable SVG supports when installing.
 
 #### Windows-specific requirements
 
@@ -118,11 +118,10 @@ You can use `-j` to enable parallel building (e.g. `cmake --build --preset PRESE
 
 Before proceeding, make sure the build preset you are using is `*-debug`. We recommend Visual Studio Code as a code editor with the following extensions:
 
-- [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
-- [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
-- [CMake](https://marketplace.visualstudio.com/items?itemName=twxs.cmake)
-- [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
-- [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
+- CMake Tools ([Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) | [Open VSX](https://open-vsx.org/extension/ms-vscode/cmake-tools))
+- clangd ([Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) | [Open VSX](https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd))
+- rust-analyzer ([Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) | [Open VSX](https://open-vsx.org/extension/rust-lang/rust-analyzer))
+- CodeLLDB ([Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) | [Open VSX](https://open-vsx.org/extension/vadimcn/vscode-lldb))
 
 Then open this folder with VS Code. It will ask which CMake preset to use and you need to choose the same one that you were using when building. Everything should work out of the box (e.g. code completion, debugging, etc).
 


### PR DESCRIPTION
It much faster than C/C++ extension from Microsoft. This also updates README to provide links to VS Code extensions on Open VSX for people who are using the open-sourced version of VS Code.