### PR TITLE
Maps VM memory

### DIFF
--- a/src/hv/build.rs
+++ b/src/hv/build.rs
@@ -1,9 +1,13 @@
 fn main() {
     match std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
-        "linux" | "android" => cc::Build::new()
-            .cpp(true)
-            .file("src/linux/kvm.cpp")
-            .compile("hvkvm"),
+        "linux" | "android" => {
+            println!("cargo::rerun-if-changed=src/linux/kvm.cpp");
+
+            cc::Build::new()
+                .cpp(true)
+                .file("src/linux/kvm.cpp")
+                .compile("obhv");
+        }
         "macos" => println!("cargo:rustc-link-lib=framework=Hypervisor"),
         _ => {}
     }

--- a/src/hv/src/darwin.rs
+++ b/src/hv/src/darwin.rs
@@ -1,5 +1,5 @@
 use crate::NewError;
-use std::ffi::c_int;
+use std::ffi::{c_int, c_void};
 use std::ptr::null_mut;
 
 /// RAII struct for `hv_vm_create` and `hv_vm_destroy`.
@@ -21,6 +21,13 @@ impl Vm {
             v => Err(v),
         }
     }
+
+    pub fn vm_map(&self, host: *mut c_void, guest: u64, len: usize) -> Result<(), c_int> {
+        match unsafe { hv_vm_map(host, guest, len, 1 | 2 | 4) } {
+            0 => Ok(()),
+            v => Err(v),
+        }
+    }
 }
 
 impl Drop for Vm {
@@ -37,4 +44,5 @@ extern "C" {
     fn hv_vm_create(config: *mut ()) -> c_int;
     fn hv_vm_destroy() -> c_int;
     fn hv_capability(capability: u64, value: *mut u64) -> c_int;
+    fn hv_vm_map(uva: *mut c_void, gpa: u64, size: usize, flags: u64) -> c_int;
 }

--- a/src/hv/src/linux/kvm.cpp
+++ b/src/hv/src/linux/kvm.cpp
@@ -5,6 +5,8 @@
 
 #include <errno.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 extern "C" int kvm_check_version(int kvm, bool *compat)
 {
@@ -39,5 +41,28 @@ extern "C" int kvm_create_vm(int kvm, int *fd)
     }
 
     *fd = vm;
+    return 0;
+}
+
+extern "C" int kvm_set_user_memory_region(
+    int vm,
+    uint32_t slot,
+    uint64_t addr,
+    uint64_t len,
+    void *mem)
+{
+    kvm_userspace_memory_region mr;
+
+    memset(&mr, 0, sizeof(mr));
+
+    mr.slot = slot;
+    mr.guest_phys_addr = addr;
+    mr.memory_size = len;
+    mr.userspace_addr = reinterpret_cast<uint64_t>(mem);
+
+    if (ioctl(vm, KVM_SET_USER_MEMORY_REGION, &mr) < 0) {
+        return errno;
+    }
+
     return 0;
 }


### PR DESCRIPTION
The reason we still use C++ with KVM is because https://crates.io/crates/kvm-ioctls is too high-level. We need something like raw KVM binding.