### PR TITLE
Moves syscall table to p_sysent

### DIFF
--- a/src/kernel/src/rtld/mod.rs
+++ b/src/kernel/src/rtld/mod.rs
@@ -119,6 +119,7 @@ impl RuntimeLinker {
             0
         };
 
+        // TODO: Check exec_new_vmspace on the PS4 to see what we have missed here.
         // TODO: Apply remaining checks from exec_self_imgact.
         // Map eboot.bin.
         let mut app = Module::map(

--- a/src/kernel/src/sysent/mod.rs
+++ b/src/kernel/src/sysent/mod.rs
@@ -1,0 +1,17 @@
+use crate::syscalls::Syscalls;
+
+/// Implementation of `sysentvec` structure.
+#[derive(Debug)]
+pub struct ProcAbi {
+    syscalls: Syscalls, // sv_size + sv_table
+}
+
+impl ProcAbi {
+    pub fn new(syscalls: Syscalls) -> Self {
+        Self { syscalls }
+    }
+
+    pub fn syscalls(&self) -> &Syscalls {
+        &self.syscalls
+    }
+}


### PR DESCRIPTION
So it is matched with FreeBSD. This will also allow us to support other binary than SELF in the future (e.g. PE).