### PR TITLE
Fixes offset related code

### DIFF
--- a/src/kernel/src/fs/host/file.rs
+++ b/src/kernel/src/fs/host/file.rs
@@ -209,7 +209,7 @@ impl HostFile {
         use std::ptr::null_mut;
         use windows_sys::Wdk::{
             Foundation::OBJECT_ATTRIBUTES,
-            Storage::FileSystem::{NtCreateFile, FILE_CREATE, FILE_DIRECTORY_FILE},
+            Storage::FileSystem::{NtCreateFile, FILE_DIRECTORY_FILE, FILE_OPEN},
         };
         use windows_sys::Win32::{
             Foundation::{RtlNtStatusToDosError, STATUS_SUCCESS, UNICODE_STRING},
@@ -256,7 +256,7 @@ impl HostFile {
                 null_mut(),
                 FILE_ATTRIBUTE_DIRECTORY,
                 FILE_SHARE_READ | FILE_SHARE_WRITE,
-                FILE_CREATE,
+                FILE_OPEN,
                 FILE_DIRECTORY_FILE,
                 null_mut(),
                 0,

--- a/src/kernel/src/fs/host/file.rs
+++ b/src/kernel/src/fs/host/file.rs
@@ -209,7 +209,7 @@ impl HostFile {
         use std::ptr::null_mut;
         use windows_sys::Wdk::{
             Foundation::OBJECT_ATTRIBUTES,
-            Storage::FileSystem::{NtCreateFile, FILE_DIRECTORY_FILE, FILE_OPEN},
+            Storage::FileSystem::{NtCreateFile, FILE_CREATE, FILE_DIRECTORY_FILE},
         };
         use windows_sys::Win32::{
             Foundation::{RtlNtStatusToDosError, STATUS_SUCCESS, UNICODE_STRING},
@@ -256,7 +256,7 @@ impl HostFile {
                 null_mut(),
                 FILE_ATTRIBUTE_DIRECTORY,
                 FILE_SHARE_READ | FILE_SHARE_WRITE,
-                FILE_OPEN,
+                FILE_CREATE,
                 FILE_DIRECTORY_FILE,
                 null_mut(),
                 0,


### PR DESCRIPTION
This PR:
- fixes a very dumb mistake in UioMut::write_with
- wraps file offset in a Gutex
- adjusts some i/o-related syscalls.

I'm still unsure whether we want to have the offset be a prt of Uio and UioMut or whether all functions should take them as a standalone argument. In order to construct Uio/UioMut properly (without uninitialized memory or fields that are set and then ignored) we would have to pass around a closure that takes and offset and only then constructs the Uio/UioMut, which is doable, but it results in some things happening in reverse order (we would lock the offset field on file and only then call copyin, which could fail - so we would have unnecessarilly locked the file offset and then fail because of something that could've been checked before)

We could create an intermediate struct that doesn't contain the offset of course, but that feels like a bit too many structs, as we already have Uio and UioMut, which is just one struct in FreeBSD, 