### PR TITLE
Implement sceprogramattribute and debuggableprocess

### DIFF
--- a/src/kernel/src/ucred/auth.rs
+++ b/src/kernel/src/ucred/auth.rs
@@ -126,11 +126,17 @@ impl AuthAttrs {
     }
 
     pub fn has_sce_program_attribute(&self) -> bool {
-        todo!()
+        (self.0[0] & 0x80000000) != 0
     }
 
     pub fn is_debuggable_process(&self) -> bool {
-        todo!()
+        let debug_attr = self.0[0];
+        if (debug_attr & 0x1000000) == 0 {
+            if (debug_attr & 0x2000000) != 0 {
+                return true;
+            }
+        }
+        return false;
     }
 
     pub fn is_unk1(&self) -> bool {


### PR DESCRIPTION
This was mainly done with comparing our other implementations to both the PS4 kernel and fpPS4.

(did you know you get these called if Webcore is true instead of false?)