### PR TITLE
Optimize m_games

### DIFF
--- a/src/game_models.cpp
+++ b/src/game_models.cpp
@@ -13,29 +13,30 @@ Game::~Game()
 {
 }
 
-QPixmap Game::icon() const
-{
+QPixmap Game::icon() const {
+    if (!m_cachedIcon.isNull()) {
+        return m_cachedIcon;
+    }
+
     // Get icon path.
     auto dir = joinPath(m_directory, "sce_sys");
     auto path = joinPath(dir.c_str(), "icon0.png");
 
-    QPixmap icon;
-
     if (QFile::exists(path.c_str())) {
-        icon.load(path.c_str());
+        m_cachedIcon.load(path.c_str());
     } else {
         // Load fallback icon if icon0 doesn't exist.
-        icon.load(":/resources/fallbackicon0.png");
+        m_cachedIcon.load(":/resources/fallbackicon0.png");
     }
 
     // For games with large icon sizes.
-    if (icon.width() != 512 || icon.height() != 512) {
-        icon = icon.scaled(512, 512, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    if (m_cachedIcon.width() != 512 || m_cachedIcon.height() != 512) {
+        m_cachedIcon = m_cachedIcon.scaled(512, 512, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
 
-    icon.setDevicePixelRatio(2.0);
+    m_cachedIcon.setDevicePixelRatio(2.0);
 
-    return icon;
+    return m_cachedIcon;
 }
 
 GameListModel::GameListModel(QObject *parent) :

--- a/src/game_models.hpp
+++ b/src/game_models.hpp
@@ -19,6 +19,7 @@ private:
     QString m_id;
     QString m_name;
     QString m_directory;
+    mutable QPixmap m_cachedIcon;
 };
 
 class GameListModel final : public QAbstractListModel {

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -106,10 +106,12 @@ MainWindow::MainWindow() :
 
     // Setup game list.
     m_games = new QListView();
+    m_games->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_games->setLayoutMode(QListView::SinglePass);
+    m_games->setModel(new GameListModel(this));
     m_games->setViewMode(QListView::IconMode);
     m_games->setWordWrap(true);
-    m_games->setContextMenuPolicy(Qt::CustomContextMenu);
-    m_games->setModel(new GameListModel(this));
+
 
     connect(m_games, &QAbstractItemView::doubleClicked, this, &MainWindow::startGame);
     connect(m_games, &QWidget::customContextMenuRequested, this, &MainWindow::requestGamesContextMenu);


### PR DESCRIPTION
I noticed an issue where any event that updated the m_games QListView would cause some lag.

Scrolling was very snappy/laggy, resizing the window would cause a delay and lag before the QListView would fit the resized window, and going from the Logs tab to the Games tab had a delay before the Games tab displayed.

I figured out that the issue was all the Icon0.pngs being reloaded EVERY time the QListView was updated. After adding a cache of the Icons, these events mentioned before are now smooth and with reduced CPU usage.
Before:
5% cpu usage when going from Logs to Games with a noticable 500ms~ delay before Games tab being displayed. (used stopwatch.)

After:
2% cpu usage when going from Logs to Games with instant feedback.