### PR TITLE
Smooth scrolling

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -26,6 +26,7 @@
 #include <QPlainTextEdit>
 #include <QProgressDialog>
 #include <QResizeEvent>
+#include <QScrollBar>
 #include <QSettings>
 #include <QStyleHints>
 #include <QTabWidget>
@@ -33,7 +34,6 @@
 #include <QUrl>
 
 #include <filesystem>
-#include <qscrollbar.h>
 
 MainWindow::MainWindow() :
     m_tab(nullptr),

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -33,6 +33,7 @@
 #include <QUrl>
 
 #include <filesystem>
+#include <qscrollbar.h>
 
 MainWindow::MainWindow() :
     m_tab(nullptr),
@@ -111,6 +112,7 @@ MainWindow::MainWindow() :
     m_games->setModel(new GameListModel(this));
     m_games->setViewMode(QListView::IconMode);
     m_games->setWordWrap(true);
+    m_games->verticalScrollBar()->setSingleStep(20);
 
 
     connect(m_games, &QAbstractItemView::doubleClicked, this, &MainWindow::startGame);


### PR DESCRIPTION
Adds steps into scrolling for Games tab similar to like what the Logs tab has.

Currently, the Games tab seemingly snaps from top to bottom when scrolling. Assumably, it is attempting to scroll a whole page.