### PR TITLE
Moves sys_get_proc_type_info to ProcManager

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,7 @@
 {
-  "cmake.configureOnOpen": true,
   "cmake.debugConfig": {
     "cwd": "${workspaceFolder}"
   },
-  "cmake.skipConfigureIfCachePresent": true,
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
@@ -12,7 +10,6 @@
   ],
   "rust-analyzer.imports.granularity.group": "module",
   "[rust]": {
-    "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true
   }
 }

--- a/src/kernel/src/process/proc.rs
+++ b/src/kernel/src/process/proc.rs
@@ -7,12 +7,10 @@ use crate::dev::DmemContainer;
 use crate::errno::{Errno, EINVAL, ERANGE, ESRCH};
 use crate::fs::Vnode;
 use crate::idt::Idt;
-use crate::info;
 use crate::syscalls::{SysErr, SysIn, SysOut, Syscalls};
 use crate::sysent::ProcAbi;
 use crate::ucred::{AuthInfo, Gid, Privilege, Ucred, Uid};
 use crate::vm::Vm;
-use bitflags::bitflags;
 use gmtx::{Gutex, GutexGroup, GutexReadGuard, GutexWriteGuard};
 use macros::Errno;
 use std::any::Any;
@@ -101,7 +99,6 @@ impl VProc {
         sys.register(487, &vp, Self::sys_cpuset_getaffinity);
         sys.register(488, &vp, Self::sys_cpuset_setaffinity);
         sys.register(587, &vp, Self::sys_get_authinfo);
-        sys.register(612, &vp, Self::sys_get_proc_type_info);
 
         vp.abi.set(ProcAbi::new(sys)).unwrap();
 
@@ -409,65 +406,6 @@ impl VProc {
         Ok(SysOut::ZERO)
     }
 
-    fn sys_get_proc_type_info(self: &Arc<Self>, td: &VThread, i: &SysIn) -> Result<SysOut, SysErr> {
-        let info = unsafe { &mut *Into::<*mut ProcTypeInfo>::into(i.args[0]) };
-
-        info!("Getting process type information.");
-
-        if info.len != size_of::<ProcTypeInfo>() {
-            return Err(SysErr::Raw(EINVAL));
-        }
-
-        *info = td.proc().get_proc_type_info();
-
-        Ok(SysOut::ZERO)
-    }
-
-    fn get_proc_type_info(&self) -> ProcTypeInfo {
-        let cred = self.cred();
-
-        let mut flags = ProcTypeInfoFlags::empty();
-
-        flags.set(
-            ProcTypeInfoFlags::IS_JIT_COMPILER_PROCESS,
-            cred.is_jit_compiler_process(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::IS_JIT_APPLICATION_PROCESS,
-            cred.is_jit_application_process(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::IS_VIDEOPLAYER_PROCESS,
-            cred.is_videoplayer_process(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::IS_DISKPLAYERUI_PROCESS,
-            cred.is_diskplayerui_process(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::HAS_USE_VIDEO_SERVICE_CAPABILITY,
-            cred.has_use_video_service_capability(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::IS_WEBCORE_PROCESS,
-            cred.is_webcore_process(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::HAS_SCE_PROGRAM_ATTRIBUTE,
-            cred.has_sce_program_attribute(),
-        );
-        flags.set(
-            ProcTypeInfoFlags::IS_DEBUGGABLE_PROCESS,
-            cred.is_debuggable_process(),
-        );
-
-        ProcTypeInfo {
-            len: size_of::<ProcTypeInfo>(),
-            ty: self.budget_ptype.into(),
-            flags,
-        }
-    }
-
     fn new_id() -> NonZeroI32 {
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
 
@@ -524,28 +462,6 @@ impl TryFrom<i32> for RtpFunction {
 struct RtPrio {
     ty: u16,
     prio: u16,
-}
-
-/// Outout of sys_get_proc_type_info.
-#[repr(C)]
-struct ProcTypeInfo {
-    len: usize,
-    ty: u32,
-    flags: ProcTypeInfoFlags,
-}
-
-bitflags! {
-    #[repr(transparent)]
-    struct ProcTypeInfoFlags: u32 {
-        const IS_JIT_COMPILER_PROCESS = 0x1;
-        const IS_JIT_APPLICATION_PROCESS = 0x2;
-        const IS_VIDEOPLAYER_PROCESS = 0x4;
-        const IS_DISKPLAYERUI_PROCESS = 0x8;
-        const HAS_USE_VIDEO_SERVICE_CAPABILITY = 0x10;
-        const IS_WEBCORE_PROCESS = 0x20;
-        const HAS_SCE_PROGRAM_ATTRIBUTE = 0x40;
-        const IS_DEBUGGABLE_PROCESS = 0x80;
-    }
 }
 
 #[derive(Debug, Error, Errno)]

--- a/src/kernel/src/regmgr/key.rs
+++ b/src/kernel/src/regmgr/key.rs
@@ -5,7 +5,6 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegKey(u32);
 
-#[allow(dead_code)] // Removes complaints about unused Regkeys.
 impl RegKey {
     pub const REGISTRY_VERSION: Self = Self(0x01010000);
     pub const REGISTRY_INSTALL: Self = Self(0x01020000);
@@ -49,10 +48,12 @@ impl RegKey {
     pub const BROWSER_DEBUG_NOTIFICATION: Self = Self(0x3CC80700);
     pub const MORPHEUS_DEBUG_VR_CAPTURE: Self = Self(0x58800C00);
     pub const DEVENV_TOOL_BOOT_PARAM: Self = Self(0x78020300);
+    pub const DEVENV_TOOL_PRELOAD_CHK_OFF: Self = Self(0x78020500);
     pub const DEVENV_TOOL_TRC_NOTIFY: Self = Self(0x78026400);
     pub const DEVENV_TOOL_USE_DEFAULT_LIB: Self = Self(0x78028300);
     pub const DEVENV_TOOL_SYS_PRX_PRELOAD: Self = Self(0x78028A00);
     pub const DEVENV_TOOL_GAME_INTMEM_DBG: Self = Self(0x7802BF00);
+    pub const DEVENV_TOOL_SCE_MODULE_DBG: Self = Self(0x7802C000);
 
     pub(super) const fn new(v: u32) -> Self {
         Self(v)
@@ -65,96 +66,60 @@ impl RegKey {
 
 impl Display for RegKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Self::REGISTRY_VERSION => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_version"),
-            Self::REGISTRY_INSTALL => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_install"),
-            Self::REGISTRY_UPDATE => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_update"),
-            Self::REGISTRY_NOT_SAVE => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_not_save"),
-            Self::REGISTRY_RECOVER => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_recover"),
-            Self::REGISTRY_DOWNGRADE => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_downgrade"),
-            Self::REGISTRY_BOOTCOUNT => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_bootcount"),
-            Self::REGISTRY_LASTVER => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_lastver"),
-            Self::REGISTRY_INIT_FLAG => f.write_str("SCE_REGMGR_ENT_KEY_REGISTRY_init_flag"),
-            Self::SYSTEM_UPDATE_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_update_mode"),
-            Self::SYSTEM_LANGUAGE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_language"),
-            Self::SYSTEM_INITIALIZE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_initialize"),
-            Self::SYSTEM_NICKNAME => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_nickname"),
-            Self::SYSTEM_DIMMER_INTERVAL => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_dimmer_interval")
-            }
-            Self::SYSTEM_EAPFUNCTION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_eapfunction"),
-            Self::SYSTEM_ENABLE_VOICERCG => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_enable_voicercg")
-            }
-            Self::SYSTEM_SOFT_VERSION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_soft_version"),
-            Self::SYSTEM_PROFILECH_VER => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_profilech_ver"),
-            Self::SYSTEM_BUTTON_ASSIGN => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_button_assign"),
-            Self::SYSTEM_BACKUP_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_backup_mode"),
-            Self::SYSTEM_PON_MEMORY_TEST => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_pon_memory_test")
-            }
-            Self::SYSTEM_GAME_REC_MODE => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_game_rec_mode"),
-            Self::SYSTEM_SHELL_FUNCTION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_shell_function"),
-            Self::SYSTEM_PAD_CONNECTION => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_pad_connection"),
-            Self::SYSTEM_DATA_TRANSFER => f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_data_transfer"),
-            Self::SYSTEM_BASE_MODE_CLKUP => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_base_mode_clkup")
-            }
-            Self::SYSTEM_NEO_VDDNB_VID_OFFSET => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_neo_vddnb_vid_offset")
-            }
-            Self::SYSTEM_TESTBUTTON_MODE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_testbutton_mode")
-            }
-            Self::SYSTEM_TESTBUTTON_PARAM => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_testbutton_param")
-            }
-            Self::SYSTEM_POWER_SHUTDOWN_STATUS => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_POWER_shutdown_status")
-            }
-            Self::SYSTEM_SPECIFIC_IDU_MODE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_SPECIFIC_idu_mode")
-            }
-            Self::SYSTEM_SPECIFIC_SHOW_MODE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_SPECIFIC_show_mode")
-            }
-            Self::SYSTEM_SPECIFIC_ARCADE_MODE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_SPECIFIC_arcade_mode")
-            }
-            Self::SYSTEM_LIBC_INTMEM_PEAK_SIZE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_LIBC_intmem_peak_size")
-            }
+        let name = match *self {
+            Self::REGISTRY_VERSION => "SCE_REGMGR_ENT_KEY_REGISTRY_version",
+            Self::REGISTRY_INSTALL => "SCE_REGMGR_ENT_KEY_REGISTRY_install",
+            Self::REGISTRY_UPDATE => "SCE_REGMGR_ENT_KEY_REGISTRY_update",
+            Self::REGISTRY_NOT_SAVE => "SCE_REGMGR_ENT_KEY_REGISTRY_not_save",
+            Self::REGISTRY_RECOVER => "SCE_REGMGR_ENT_KEY_REGISTRY_recover",
+            Self::REGISTRY_DOWNGRADE => "SCE_REGMGR_ENT_KEY_REGISTRY_downgrade",
+            Self::REGISTRY_BOOTCOUNT => "SCE_REGMGR_ENT_KEY_REGISTRY_bootcount",
+            Self::REGISTRY_LASTVER => "SCE_REGMGR_ENT_KEY_REGISTRY_lastver",
+            Self::REGISTRY_INIT_FLAG => "SCE_REGMGR_ENT_KEY_REGISTRY_init_flag",
+            Self::SYSTEM_UPDATE_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_update_mode",
+            Self::SYSTEM_LANGUAGE => "SCE_REGMGR_ENT_KEY_SYSTEM_language",
+            Self::SYSTEM_INITIALIZE => "SCE_REGMGR_ENT_KEY_SYSTEM_initialize",
+            Self::SYSTEM_NICKNAME => "SCE_REGMGR_ENT_KEY_SYSTEM_nickname",
+            Self::SYSTEM_DIMMER_INTERVAL => "SCE_REGMGR_ENT_KEY_SYSTEM_dimmer_interval",
+            Self::SYSTEM_EAPFUNCTION => "SCE_REGMGR_ENT_KEY_SYSTEM_eapfunction",
+            Self::SYSTEM_ENABLE_VOICERCG => "SCE_REGMGR_ENT_KEY_SYSTEM_enable_voicercg",
+            Self::SYSTEM_SOFT_VERSION => "SCE_REGMGR_ENT_KEY_SYSTEM_soft_version",
+            Self::SYSTEM_PROFILECH_VER => "SCE_REGMGR_ENT_KEY_SYSTEM_profilech_ver",
+            Self::SYSTEM_BUTTON_ASSIGN => "SCE_REGMGR_ENT_KEY_SYSTEM_button_assign",
+            Self::SYSTEM_BACKUP_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_backup_mode",
+            Self::SYSTEM_PON_MEMORY_TEST => "SCE_REGMGR_ENT_KEY_SYSTEM_pon_memory_test",
+            Self::SYSTEM_GAME_REC_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_game_rec_mode",
+            Self::SYSTEM_SHELL_FUNCTION => "SCE_REGMGR_ENT_KEY_SYSTEM_shell_function",
+            Self::SYSTEM_PAD_CONNECTION => "SCE_REGMGR_ENT_KEY_SYSTEM_pad_connection",
+            Self::SYSTEM_DATA_TRANSFER => "SCE_REGMGR_ENT_KEY_SYSTEM_data_transfer",
+            Self::SYSTEM_BASE_MODE_CLKUP => "SCE_REGMGR_ENT_KEY_SYSTEM_base_mode_clkup",
+            Self::SYSTEM_NEO_VDDNB_VID_OFFSET => "SCE_REGMGR_ENT_KEY_SYSTEM_neo_vddnb_vid_offset",
+            Self::SYSTEM_TESTBUTTON_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_testbutton_mode",
+            Self::SYSTEM_TESTBUTTON_PARAM => "SCE_REGMGR_ENT_KEY_SYSTEM_testbutton_param",
+            Self::SYSTEM_POWER_SHUTDOWN_STATUS => "SCE_REGMGR_ENT_KEY_SYSTEM_POWER_shutdown_status",
+            Self::SYSTEM_SPECIFIC_IDU_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_SPECIFIC_idu_mode",
+            Self::SYSTEM_SPECIFIC_SHOW_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_SPECIFIC_show_mode",
+            Self::SYSTEM_SPECIFIC_ARCADE_MODE => "SCE_REGMGR_ENT_KEY_SYSTEM_SPECIFIC_arcade_mode",
+            Self::SYSTEM_LIBC_INTMEM_PEAK_SIZE => "SCE_REGMGR_ENT_KEY_SYSTEM_LIBC_intmem_peak_size",
             Self::SYSTEM_LIBC_INTMEM_SHORTAGE_COUNT => {
-                f.write_str("SCE_REGMGR_ENT_KEY_SYSTEM_LIBC_intmem_shortage_count")
+                "SCE_REGMGR_ENT_KEY_SYSTEM_LIBC_intmem_shortage_count"
             }
-            Self::AUDIOOUT_CONNECTOR_TYPE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_AUDIOOUT_connector_type")
-            }
-            Self::AUDIOOUT_CODEC => f.write_str("SCE_REGMGR_ENT_KEY_AUDIOOUT_codec"),
-            Self::NET_WIFI_FREQ_BAND => f.write_str("SCE_REGMGR_ENT_KEY_NET_WIFI_freq_band"),
-            Self::NP_DEBUG => f.write_str("SCE_REGMGR_ENT_KEY_NP_debug"),
-            Self::BROWSER_DEBUG_NOTIFICATION => {
-                f.write_str("SCE_REGMGR_ENT_KEY_BROWSER_DEBUG_notification")
-            }
-            Self::MORPHEUS_DEBUG_VR_CAPTURE => {
-                f.write_str("SCE_REGMGR_ENT_KEY_MORPHEUS_DEBUG_vr_capture")
-            }
-            Self::DEVENV_TOOL_BOOT_PARAM => {
-                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_boot_param")
-            }
-            Self::DEVENV_TOOL_TRC_NOTIFY => {
-                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_trc_notify")
-            }
-            Self::DEVENV_TOOL_USE_DEFAULT_LIB => {
-                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_use_default_lib")
-            }
-            Self::DEVENV_TOOL_SYS_PRX_PRELOAD => {
-                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_sys_prx_preload")
-            }
-            Self::DEVENV_TOOL_GAME_INTMEM_DBG => {
-                f.write_str("SCE_REGMGR_ENT_KEY_DEVENV_TOOL_game_intmem_dbg")
-            }
-            v => write!(f, "{:#x}", v.0),
-        }
+            Self::AUDIOOUT_CONNECTOR_TYPE => "SCE_REGMGR_ENT_KEY_AUDIOOUT_connector_type",
+            Self::AUDIOOUT_CODEC => "SCE_REGMGR_ENT_KEY_AUDIOOUT_codec",
+            Self::NET_WIFI_FREQ_BAND => "SCE_REGMGR_ENT_KEY_NET_WIFI_freq_band",
+            Self::NP_DEBUG => "SCE_REGMGR_ENT_KEY_NP_debug",
+            Self::BROWSER_DEBUG_NOTIFICATION => "SCE_REGMGR_ENT_KEY_BROWSER_DEBUG_notification",
+            Self::MORPHEUS_DEBUG_VR_CAPTURE => "SCE_REGMGR_ENT_KEY_MORPHEUS_DEBUG_vr_capture",
+            Self::DEVENV_TOOL_BOOT_PARAM => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_boot_param",
+            Self::DEVENV_TOOL_PRELOAD_CHK_OFF => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_preload_chk_off",
+            Self::DEVENV_TOOL_TRC_NOTIFY => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_trc_notify",
+            Self::DEVENV_TOOL_USE_DEFAULT_LIB => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_use_default_lib",
+            Self::DEVENV_TOOL_SYS_PRX_PRELOAD => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_sys_prx_preload",
+            Self::DEVENV_TOOL_GAME_INTMEM_DBG => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_game_intmem_dbg",
+            Self::DEVENV_TOOL_SCE_MODULE_DBG => "SCE_REGMGR_ENT_KEY_DEVENV_TOOL_sce_module_dbg",
+            v => return write!(f, "{:#x}", v.0),
+        };
+
+        f.write_str(name)
     }
 }

--- a/src/kernel/src/ucred/auth.rs
+++ b/src/kernel/src/ucred/auth.rs
@@ -87,12 +87,12 @@ impl AuthCaps {
         (self.0[0] & 0x2000000000000000) != 0
     }
 
-    pub fn has_use_video_service_capability(&self) -> bool {
-        self.0[0] >> 0x39 & 1 != 0
-    }
-
     pub fn is_system(&self) -> bool {
         (self.0[0] & 0x4000000000000000) != 0
+    }
+
+    pub fn has_use_video_service(&self) -> bool {
+        (self.0[1] & 0x0200000000000000) != 0
     }
 
     pub fn is_unk1(&self) -> bool {
@@ -117,28 +117,27 @@ impl AuthAttrs {
         Self(raw)
     }
 
-    pub fn has_sce_program_attribute(&self) -> bool {
-        (self.0[0] & 0x80000000) != 0
+    pub fn is_unk2(&self) -> bool {
+        (self.0[0] & 0x00400000) != 0
+    }
+
+    pub fn is_unk1(&self) -> bool {
+        (self.0[0] & 0x00800000) != 0
     }
 
     pub fn is_debuggable_process(&self) -> bool {
-        if self.0[0] & 0x1000000 == 0 {
-            if self.0[0] & 0x2000000 != 0 {
+        if self.0[0] & 0x01000000 == 0 {
+            if self.0[0] & 0x02000000 != 0 {
                 true
             } else {
-                // TODO: properly implement this branch.
-                false
+                todo!()
             }
         } else {
             todo!()
         }
     }
 
-    pub fn is_unk1(&self) -> bool {
-        (self.0[0] & 0x800000) != 0
-    }
-
-    pub fn is_unk2(&self) -> bool {
-        (self.0[0] & 0x400000) != 0
+    pub fn has_sce_program_attribute(&self) -> bool {
+        (self.0[0] & 0x80000000) != 0
     }
 }

--- a/src/kernel/src/ucred/mod.rs
+++ b/src/kernel/src/ucred/mod.rs
@@ -116,7 +116,7 @@ impl Ucred {
 
     /// See `sceSblACMgrHasUseVideoServiceCapability` on the PS4 for a reference.
     pub fn has_use_video_service_capability(&self) -> bool {
-        self.auth.caps.has_use_video_service_capability()
+        self.auth.caps.has_use_video_service()
     }
 
     /// See `sceSblACMgrIsWebcoreProcess` on the PS4 for a reference.


### PR DESCRIPTION
This also fix some bugs related to this syscall, remove unused VS Code settings and add 2 regmgr keys.