### PR TITLE
Removes VFileType

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "settings set target.x86-disassembly-flavor intel"
   ],
   "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.imports.group.enable": false,
   "[rust]": {
     "editor.formatOnSave": true
   }

--- a/src/kernel/src/dmem/blockpool.rs
+++ b/src/kernel/src/dmem/blockpool.rs
@@ -1,6 +1,7 @@
 use crate::errno::Errno;
-use crate::fs::{DefaultFileBackendError, FileBackend, IoCmd, PollEvents, Stat, VFile};
+use crate::fs::{DefaultFileBackendError, FileBackend, IoCmd, PollEvents, Stat, VFile, Vnode};
 use crate::process::VThread;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct BlockPool {}
@@ -37,6 +38,10 @@ impl FileBackend for BlockPool {
         stat.mode = 0o130000;
 
         todo!()
+    }
+
+    fn vnode(&self) -> Option<&Arc<Vnode>> {
+        None
     }
 }
 

--- a/src/kernel/src/dmem/mod.rs
+++ b/src/kernel/src/dmem/mod.rs
@@ -1,8 +1,8 @@
+use self::blockpool::BlockPool;
 use crate::dev::{Dmem, DmemContainer};
 use crate::errno::EINVAL;
 use crate::fs::{
-    make_dev, CharacterDevice, DriverFlags, Fs, MakeDevError, MakeDevFlags, Mode, VFile,
-    VFileFlags, VFileType,
+    make_dev, CharacterDevice, DriverFlags, Fs, MakeDevError, MakeDevFlags, Mode, VFile, VFileFlags,
 };
 use crate::info;
 use crate::process::VThread;
@@ -12,7 +12,7 @@ use std::ops::Index;
 use std::sync::Arc;
 use thiserror::Error;
 
-pub use self::blockpool::*;
+pub use self::blockpool::{BlockpoolExpandArgs, BlockpoolStats};
 
 mod blockpool;
 
@@ -134,15 +134,11 @@ impl DmemManager {
         }
 
         let bp = BlockPool::new();
-
         let flags = VFileFlags::from_bits_retain(flags) | VFileFlags::WRITE;
-
-        let fd = td.proc().files().alloc(Arc::new(VFile::new(
-            VFileType::Blockpool,
-            flags,
-            None,
-            Box::new(bp),
-        )));
+        let fd = td
+            .proc()
+            .files()
+            .alloc(Arc::new(VFile::new(flags, Box::new(bp))));
 
         info!("Opened a blockpool at fd = {fd}");
 

--- a/src/kernel/src/fs/dev/vnode.rs
+++ b/src/kernel/src/fs/dev/vnode.rs
@@ -196,7 +196,7 @@ impl crate::fs::VnodeBackend for VnodeBackend {
 
     fn to_file_backend(&self, vn: &Arc<Vnode>) -> Box<dyn FileBackend> {
         match vn.item().deref() {
-            Some(VnodeItem::Device(d)) => Box::new(CdevFileBackend::new(d.clone())),
+            Some(VnodeItem::Device(d)) => Box::new(CdevFileBackend::new(vn.clone(), d.clone())),
             _ => Box::new(VnodeFileBackend::new(vn.clone())),
         }
     }

--- a/src/kernel/src/fs/mod.rs
+++ b/src/kernel/src/fs/mod.rs
@@ -181,7 +181,7 @@ impl Fs {
             .map_err(OpenError::LookupFailed)?;
         let backend = vnode.to_file_backend();
 
-        Ok(VFile::new(VFileType::Vnode, flags, Some(vnode), backend))
+        Ok(VFile::new(flags, backend))
     }
 
     pub fn lookup(

--- a/src/kernel/src/fs/vnode.rs
+++ b/src/kernel/src/fs/vnode.rs
@@ -2,7 +2,6 @@ use super::{
     unixify_access, Access, CharacterDevice, FileBackend, IoCmd, IoLen, IoVec, IoVecMut, Mode,
     Mount, PollEvents, RevokeFlags, Stat, TruncateLength, VFile,
 };
-use crate::arnd;
 use crate::errno::{Errno, ENOTDIR, ENOTTY, EOPNOTSUPP, EPERM};
 use crate::process::VThread;
 use crate::ucred::{Gid, Uid};
@@ -47,8 +46,7 @@ impl Vnode {
             backend: Box::new(backend),
             hash: {
                 let mut buf = [0u8; 4];
-                arnd::rand_bytes(&mut buf);
-
+                crate::arnd::rand_bytes(&mut buf);
                 u32::from_ne_bytes(buf)
             },
             item: gg.spawn(None),
@@ -343,6 +341,10 @@ impl FileBackend for VnodeFileBackend {
         td: Option<&VThread>,
     ) -> Result<(), Box<dyn Errno>> {
         todo!()
+    }
+
+    fn vnode(&self) -> Option<&Arc<Vnode>> {
+        Some(&self.0)
     }
 }
 

--- a/src/kernel/src/kqueue/mod.rs
+++ b/src/kernel/src/kqueue/mod.rs
@@ -1,7 +1,7 @@
 use crate::budget::BudgetType;
 use crate::errno::Errno;
 use crate::fs::{
-    DefaultFileBackendError, PollEvents, Stat, TruncateLength, VFile, VFileFlags, VFileType,
+    DefaultFileBackendError, PollEvents, Stat, TruncateLength, VFile, VFileFlags, Vnode,
 };
 use crate::process::{FileDesc, VThread};
 use crate::syscalls::{SysErr, SysIn, SysOut, Syscalls};
@@ -34,9 +34,7 @@ impl KernelQueueManager {
                 filedesc.insert_kqueue(kq.clone());
 
                 Ok(VFile::new(
-                    VFileType::KernelQueue,
                     VFileFlags::READ | VFileFlags::WRITE,
-                    None,
                     Box::new(FileBackend(kq)),
                 ))
             },
@@ -89,5 +87,9 @@ impl crate::fs::FileBackend for FileBackend {
         _: Option<&VThread>,
     ) -> Result<(), Box<dyn Errno>> {
         Err(Box::new(DefaultFileBackendError::InvalidValue))
+    }
+
+    fn vnode(&self) -> Option<&Arc<Vnode>> {
+        None
     }
 }

--- a/src/kernel/src/process/filedesc.rs
+++ b/src/kernel/src/process/filedesc.rs
@@ -1,8 +1,7 @@
 use crate::budget::BudgetType;
-use crate::errno::{Errno, EBADF, ENOTSOCK};
-use crate::fs::{VFile, VFileFlags, VFileType, Vnode};
+use crate::errno::{Errno, EBADF};
+use crate::fs::{VFile, VFileFlags, Vnode};
 use crate::kqueue::KernelQueue;
-use crate::net::Socket;
 use gmtx::{Gutex, GutexGroup};
 use macros::Errno;
 use std::collections::VecDeque;
@@ -113,19 +112,6 @@ impl FileDesc {
         panic!("Too many files has been opened.");
     }
 
-    // TODO: (maybe) implement capabilities
-
-    /// See `getsock_cap` on the PS4 for a reference.
-    pub fn get_socket(&self, fd: i32) -> Result<Arc<Socket>, GetSocketError> {
-        let file = self.get(fd)?;
-
-        let (VFileType::Socket | VFileType::IpcSocket) = file.ty() else {
-            return Err(GetSocketError::NotSocket);
-        };
-
-        Ok(todo!())
-    }
-
     /// See `fget` on the PS4 for a reference.
     pub fn get(&self, fd: i32) -> Result<Arc<VFile>, GetFileError> {
         self.get_internal(fd, VFileFlags::empty())
@@ -179,16 +165,6 @@ impl FileDesc {
             Err(FreeError::NoFile)
         }
     }
-}
-
-#[derive(Debug, Error, Errno)]
-pub enum GetSocketError {
-    #[error("failed to get file")]
-    GetFileError(#[from] GetFileError),
-
-    #[error("file is not a socket")]
-    #[errno(ENOTSOCK)]
-    NotSocket,
 }
 
 #[derive(Debug, Error, Errno)]

--- a/src/kernel/src/shm/mod.rs
+++ b/src/kernel/src/shm/mod.rs
@@ -2,6 +2,7 @@ use crate::errno::{Errno, EINVAL};
 use crate::fs::{
     check_access, Access, AccessError, DefaultFileBackendError, FileBackend, IoCmd, IoLen, IoVec,
     IoVecMut, Mode, OpenFlags, PollEvents, Stat, TruncateLength, VFile, VFileFlags, VPathBuf,
+    Vnode,
 };
 use crate::process::VThread;
 use crate::syscalls::{SysErr, SysIn, SysOut, Syscalls};
@@ -67,7 +68,7 @@ pub enum ShmPath {
 /// An implementation of the `shmfd` structure.
 #[derive(Debug)]
 #[allow(unused_variables)] // TODO: remove when used.
-pub struct SharedMemory {
+struct SharedMemory {
     uid: Uid,
     gid: Gid,
     mode: Mode,
@@ -152,6 +153,10 @@ impl FileBackend for SharedMemory {
         self.do_truncate(length)?;
 
         Ok(())
+    }
+
+    fn vnode(&self) -> Option<&Arc<Vnode>> {
+        todo!()
     }
 }
 


### PR DESCRIPTION
AFAIK its only purpose is to identify what is stored at `f_data` so it is redundant in our case.

Resolves #848.