### PR TITLE
Fix the UI version stuff

### DIFF
--- a/src/core/src/param.rs
+++ b/src/core/src/param.rs
@@ -65,5 +65,8 @@ pub unsafe extern "C" fn param_title_id_get(param: &Param, buf: &mut QString) {
 
 #[no_mangle]
 pub unsafe extern "C" fn param_version_get(param: &Param, buf: &mut QString) {
-    buf.set(param.version());
+    match param.version() {
+        Some(version) => buf.set(version),
+        None => buf.set(""),
+    }
 }

--- a/src/param/src/lib.rs
+++ b/src/param/src/lib.rs
@@ -12,7 +12,7 @@ pub struct Param {
     content_id: Box<str>,
     title: Option<Box<str>>,
     title_id: Box<str>,
-    version: Box<str>,
+    version: Option<Box<str>>,
 }
 
 impl Param {
@@ -166,7 +166,7 @@ impl Param {
             content_id: content_id.ok_or(ReadError::MissingContentId)?,
             title,
             title_id: title_id.ok_or(ReadError::MissingTitleId)?,
-            version: version.ok_or(ReadError::MissingVersion)?,
+            version: version,
         })
     }
 
@@ -204,8 +204,8 @@ impl Param {
     }
 
     /// Fetches the value VERSION from given Param.SFO
-    pub fn version(&self) -> &str {
-        &self.version
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
     }
 
     fn read_utf8<R: Read>(
@@ -276,7 +276,4 @@ pub enum ReadError {
 
     #[error("TITLE_ID parameter not found")]
     MissingTitleId,
-
-    #[error("VERSION parameter not found")]
-    MissingVersion,
 }


### PR DESCRIPTION
Makes it so Version returns blank for Qt if there is no Version...

App_Ver still exists, so Log returns

```
Application ID      : NPXS20001
Application Category: gdf
Application Version : 01.00
```