### PR TITLE
Hack for running static elfs

### DIFF
--- a/src/kernel/src/ee/native/mod.rs
+++ b/src/kernel/src/ee/native/mod.rs
@@ -665,8 +665,8 @@ impl NativeEngine {
 #[derive(Debug)]
 pub struct RawFn {
     #[allow(unused)]
-    md: Arc<dyn Any + Send + Sync>, // Keep module alive.
-    addr: usize,
+    pub md: Arc<dyn Any + Send + Sync>, // Keep module alive.
+    pub addr: usize,
 }
 
 impl RawFn {

--- a/src/kernel/src/rtld/mem.rs
+++ b/src/kernel/src/rtld/mem.rs
@@ -70,7 +70,7 @@ impl Memory {
             }
 
             // Get offset and length.
-            let start = base + prog.addr();
+            let start = prog.addr();
             let len = prog.aligned_size();
 
             if start & 0x3fff != 0 {
@@ -146,7 +146,7 @@ impl Memory {
 
         // TODO: Use separate name for our code and data.
         let mut pages = match proc.vm().mmap(
-            0,
+            base as _,
             len,
             Protections::empty(),
             name,
@@ -288,7 +288,7 @@ impl Memory {
         seg: usize,
     ) -> Result<UnprotectedSegment<'_>, UnprotectSegmentError> {
         let seg = &self.segments[seg];
-        let ptr = self.ptr.add(seg.start);
+        let ptr = seg.start as _;
         let len = seg.len;
         let prot = Protections::CPU_READ | Protections::CPU_WRITE;
 

--- a/src/kernel/src/rtld/mod.rs
+++ b/src/kernel/src/rtld/mod.rs
@@ -100,7 +100,7 @@ impl RuntimeLinker {
         match elf.ty() {
             FileType::ET_EXEC | FileType::ET_SCE_EXEC | FileType::ET_SCE_REPLAY_EXEC => {
                 if elf.info().is_none() {
-                    todo!("a statically linked eboot.bin is not supported yet.");
+                    info!("a statically linked eboot.bin is not tested");
                 }
             }
             FileType::ET_SCE_DYNEXEC if elf.dynamic().is_some() => {}

--- a/src/kernel/src/rtld/module.rs
+++ b/src/kernel/src/rtld/module.rs
@@ -88,7 +88,7 @@ impl Module {
                 assert_ne!(p.addr(), 0);
                 assert_ne!(p.memory_size(), 0);
 
-                let header = base + p.addr();
+                let header = p.addr();
                 let header_size = p.memory_size();
                 let (frame, frame_size) = unsafe { Self::digest_eh(&memory, header, header_size) };
 
@@ -390,12 +390,7 @@ impl Module {
         }
 
         if let Some(v) = self.entry {
-            writeln!(
-                entry,
-                "Entry address : {:#018x}",
-                mem.addr() + mem.base() + v
-            )
-            .unwrap();
+            writeln!(entry, "Entry address : {:#018x}", v).unwrap();
         }
 
         if let Some(v) = self.fini {
@@ -450,7 +445,7 @@ impl Module {
                 None => continue,
             };
 
-            let addr = mem.addr() + s.start();
+            let addr = s.start();
 
             writeln!(
                 entry,
@@ -474,7 +469,7 @@ impl Module {
         // Let it panic because the PS4 assume the index is valid.
         let frame: isize = LE::read_i32(&hdr[4..]).try_into().unwrap();
 
-        assert_ne!(frame, 0);
+        // assert_ne!(frame, 0);
 
         // Get first frame.
         let frame: usize = match hdr[1] {

--- a/src/kernel/src/vm/storage.rs
+++ b/src/kernel/src/vm/storage.rs
@@ -23,9 +23,18 @@ pub(super) struct Memory {
 impl Memory {
     #[cfg(unix)]
     pub fn new(addr: usize, len: usize) -> Result<Self, Error> {
-        use libc::{mmap, MAP_ANON, MAP_FAILED, MAP_PRIVATE, PROT_NONE};
+        use libc::{mmap, MAP_ANON, MAP_FAILED, MAP_FIXED, MAP_PRIVATE, PROT_NONE};
 
-        let addr = unsafe { mmap(addr as _, len, PROT_NONE, MAP_PRIVATE | MAP_ANON, -1, 0) };
+        let addr = unsafe {
+            mmap(
+                addr as _,
+                len,
+                PROT_NONE,
+                MAP_PRIVATE | MAP_ANON | (if addr != 0 { MAP_FIXED } else { 0 }),
+                -1,
+                0,
+            )
+        };
 
         if addr == MAP_FAILED {
             return Err(Error::last_os_error());

--- a/src/kernel/src/vm/vm.rs
+++ b/src/kernel/src/vm/vm.rs
@@ -484,7 +484,7 @@ impl Vm {
             // allocation will be large enough for a second allocation with fixed address.
             // The whole idea is coming from: https://stackoverflow.com/a/31411825/1829232
             let len = len + (Self::VIRTUAL_PAGE_SIZE - self.allocation_granularity);
-            let storage = Memory::new(addr, len)?;
+            let storage = Memory::new(if name == "executable" { 0x400000 } else { 0 }, len)?;
 
             // Do the second allocation.
             let addr = Self::align_virtual_page(storage.addr());
@@ -494,7 +494,7 @@ impl Vm {
         } else {
             // If allocation granularity is equal or larger than the virtual page that mean the
             // result of mmap will always aligned correctly.
-            let storage = Memory::new(addr, len)?;
+            let storage = Memory::new(if name == "executable" { 0x400000 } else { 0 }, len)?;
             let addr = storage.addr();
 
             (addr, len, storage)


### PR DESCRIPTION
To run a static elf, it needs to be loaded at 0x400000, and the execution is to be started at the entry address, not through libkernel. As an example, SceSysAvControl.elf defined _entry at 0x400080. This makes running static elfs incompatible with Windows IIRC, at least without further major hacks.

It is nowhere near ready to be merged, but I'm looking for any pointers and suggestions. If you could comment and suggest changes to make it more correct, I'd appreciate that.