### PR TITLE
Moves logs viewer into a dedicated Window

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(obliteration WIN32 MACOSX_BUNDLE
     initialize_wizard.cpp
     launch_settings.cpp
     log_formatter.cpp
+    logs_viewer.cpp
     main.cpp
     main_window.cpp
     path.cpp

--- a/src/logs_viewer.cpp
+++ b/src/logs_viewer.cpp
@@ -1,0 +1,39 @@
+#include "logs_viewer.hpp"
+#include "log_formatter.hpp"
+
+#include <QHBoxLayout>
+#include <QPlainTextEdit>
+
+LogsViewer::LogsViewer() :
+    m_formatter(nullptr)
+{
+    auto layout = new QHBoxLayout();
+
+    setWindowTitle("Obliteration Logs");
+
+    // Setup viewer.
+    auto viewer = new QPlainTextEdit();
+
+    viewer->setReadOnly(true);
+    viewer->setLineWrapMode(QPlainTextEdit::NoWrap);
+    viewer->setMaximumBlockCount(10000);
+
+#ifdef _WIN32
+    viewer->document()->setDefaultFont(QFont("Courier New", 10));
+#elif __APPLE__
+    viewer->document()->setDefaultFont(QFont("menlo", 10));
+#else
+    viewer->document()->setDefaultFont(QFont("monospace", 10));
+#endif
+
+    layout->addWidget(viewer);
+
+    // Setup formatter.
+    m_formatter = new LogFormatter(viewer, this);
+
+    setLayout(layout);
+}
+
+LogsViewer::~LogsViewer()
+{
+}

--- a/src/logs_viewer.hpp
+++ b/src/logs_viewer.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QWidget>
+
+class LogFormatter;
+
+class LogsViewer final : public QWidget {
+public:
+    LogsViewer();
+    ~LogsViewer() override;
+private:
+    LogFormatter *m_formatter;
+};

--- a/src/main_window.hpp
+++ b/src/main_window.hpp
@@ -3,9 +3,10 @@
 #include "core.hpp"
 
 #include <QMainWindow>
+#include <QPointer>
 
 class LaunchSettings;
-class LogFormatter;
+class LogsViewer;
 class QStackedWidget;
 class QTableView;
 
@@ -23,6 +24,7 @@ protected:
 private slots:
     void installPkg();
     void openSystemFolder();
+    void viewLogs();
     void reportIssue();
     void aboutObliteration();
     void requestGamesContextMenu(const QPoint &pos);
@@ -38,6 +40,6 @@ private:
     QStackedWidget *m_screen;
     LaunchSettings *m_launch;
     QTableView *m_games;
-    LogFormatter *m_log;
+    QPointer<LogsViewer> m_logs;
     RustPtr<Vmm> m_kernel;
 };

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -2,7 +2,6 @@
 <RCC version="1.0">
   <qresource>
     <file>resources/archive-arrow-down-outline.svg</file>
-    <file>resources/card-text-outline.svg</file>
     <file>resources/cog-outline.svg</file>
     <file>resources/fallbackicon0.png</file>
     <file>resources/folder-open-outline.svg</file>

--- a/src/resources/card-text-outline.svg
+++ b/src/resources/card-text-outline.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20M4,6V18H20V6H4M6,9H18V11H6V9M6,13H16V15H6V13Z" /></svg>


### PR DESCRIPTION
The idea is we will use the whole main window as a display and a launch settings. Once user click on a start button it will swap out the settings widget with `QVulkanWindow`.