### PR TITLE
Fixes incorrect kernel mapping

### DIFF
--- a/src/core/src/vmm/hw/ram/mod.rs
+++ b/src/core/src/vmm/hw/ram/mod.rs
@@ -160,17 +160,8 @@ unsafe impl Sync for Ram {}
 /// Represents an error when an operation on [`Ram`] fails.
 #[derive(Debug, Error)]
 pub enum RamError {
-    #[error("unaligned address")]
-    UnalignedAddr,
-
-    #[error("overlapped address")]
-    OverlappedAddr,
-
     #[error("invalid address")]
     InvalidAddr,
-
-    #[error("invalid length")]
-    InvalidLen,
 
     #[error("host failed")]
     HostFailed(#[source] std::io::Error),


### PR DESCRIPTION
#925 cause this bug. Each `PT_LOAD` may not have `p_vaddr` aligned to optimize when each segment is mapped with `mmap`:

```
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000000040 0x0000000000000040
                 0x00000000000001c0 0x00000000000001c0  R      0x8
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000262 0x0000000000000262  R      0x4000
  LOAD           0x0000000000000270 0x0000000000004270 0x0000000000004270
                 0x0000000000000135 0x0000000000000135  R E    0x4000
  LOAD           0x00000000000003a8 0x00000000000083a8 0x00000000000083a8
                 0x00000000000000a0 0x0000000000003c58  RW     0x4000
  LOAD           0x0000000000000448 0x000000000000c448 0x000000000000c448
                 0x0000000000000000 0x0000000000000008  RW     0x4000
  DYNAMIC        0x00000000000003a8 0x00000000000083a8 0x00000000000083a8
                 0x00000000000000a0 0x00000000000000a0  RW     0x8
  GNU_RELRO      0x00000000000003a8 0x00000000000083a8 0x00000000000083a8
                 0x00000000000000a0 0x0000000000003c58  R      0x1
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x0
```