### PR TITLE
Produces PIE kernel for AArch64

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -69,6 +69,8 @@ jobs:
       if: ${{ steps.qt-cache.outputs.cache-hit != 'true' }}
     - name: Update Rust
       run: rustup update stable
+    - name: Install Rust nightly
+      run: rustup toolchain install nightly
     - name: Add additional Rust targets
       run: rustup target add ${{ inputs.kernel-target }}
     - name: Run CMake

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -71,7 +71,9 @@ jobs:
       run: rustup update stable
     - name: Install Rust nightly
       run: rustup toolchain install nightly
-    - name: Add additional Rust targets
+    - name: Install additional Rust components
+      run: rustup component add rust-src --toolchain nightly
+    - name: Install additional Rust targets
       run: rustup target add ${{ inputs.kernel-target }}
     - name: Run CMake
       run: cmake --preset mac-release .

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,12 @@ else()
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
         set(KERNEL_TARGET x86_64-unknown-none)
     elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64")
+        # Pre-compiled core crate for aarch64-unknown-none-softfloat does not support
+        # Position-Independent Executable so we need nightly toolchain for build-std feature to
+        # re-build core crate to support Position-Independent Executable.
         set(KERNEL_TARGET aarch64-unknown-none-softfloat)
+        set(KERNEL_TOOLCHAIN +nightly)
+        set(KERNEL_OPTS -Z build-std=core,alloc)
     else()
         message(FATAL_ERROR "Target CPU is not supported")
     endif()
@@ -39,7 +44,7 @@ add_custom_target(core
     BYPRODUCTS ${LIBCORE})
 
 add_custom_target(kernel
-    COMMAND cargo build $<IF:$<CONFIG:Debug>,--profile=dev,--release> --target ${KERNEL_TARGET}
+    COMMAND cargo ${KERNEL_TOOLCHAIN} build $<IF:$<CONFIG:Debug>,--profile=dev,--release> --target ${KERNEL_TARGET} ${KERNEL_OPTS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/obkrnl
     BYPRODUCTS ${KERNEL})
 

--- a/src/obkrnl/.cargo/config.toml
+++ b/src/obkrnl/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-none-softfloat]
+rustflags = ["-C", "relocation-model=pic"]

--- a/src/obkrnl/build.rs
+++ b/src/obkrnl/build.rs
@@ -1,8 +1,16 @@
 fn main() {
-    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target = std::env::var("TARGET").unwrap();
 
-    if os == "none" {
-        println!("cargo::rustc-link-arg-bins=-zcommon-page-size=0x4000");
-        println!("cargo::rustc-link-arg-bins=-zmax-page-size=0x4000");
+    match target.as_str() {
+        "aarch64-unknown-none-softfloat" => {
+            println!("cargo::rustc-link-arg-bins=--pie");
+            println!("cargo::rustc-link-arg-bins=-zcommon-page-size=0x4000");
+            println!("cargo::rustc-link-arg-bins=-zmax-page-size=0x4000");
+        }
+        "x86_64-unknown-none" => {
+            println!("cargo::rustc-link-arg-bins=-zcommon-page-size=0x4000");
+            println!("cargo::rustc-link-arg-bins=-zmax-page-size=0x4000");
+        }
+        _ => {}
     }
 }


### PR DESCRIPTION
According to [Memory Layout on AArch64 Linux](https://www.kernel.org/doc/html/v5.8/arm64/memory.html) and ARM [AArch64 memory management Guide](https://developer.arm.com/documentation/101811/0103/Address-spaces/Size-of-virtual-addresses) seems like we need a higher half kernel here, the same as x86-64. That mean we need PIE kernel. Unfortunately the pre-built core crate from Rust use [static](https://github.com/rust-lang/rust/blob/master/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs#L19) relocation so we need to re-build it using `build-std` feature, which is only available on nightly.

This does not mean we are freely to use other nightly features. The x86-64 version and all code must continue to use only the stable features.