### PR TITLE
Prepares VMM to supports multiple page size

### DIFF
--- a/src/core/src/vmm/hv/linux/mod.rs
+++ b/src/core/src/vmm/hv/linux/mod.rs
@@ -83,11 +83,10 @@ impl Kvm {
         // Set RAM.
         let vm = unsafe { OwnedFd::from_raw_fd(vm) };
         let slot = 0;
-        let addr = ram.addr().try_into().unwrap();
         let len = ram.len().try_into().unwrap();
         let mem = ram.host_addr().cast_mut().cast();
 
-        match unsafe { kvm_set_user_memory_region(vm.as_raw_fd(), slot, addr, len, mem) } {
+        match unsafe { kvm_set_user_memory_region(vm.as_raw_fd(), slot, 0, len, mem) } {
             0 => {}
             v => return Err(VmmError::MapRamFailed(Error::from_raw_os_error(v))),
         }

--- a/src/core/src/vmm/hv/macos/mod.rs
+++ b/src/core/src/vmm/hv/macos/mod.rs
@@ -26,12 +26,8 @@ impl Hf {
         let vm = Vm::new().map_err(VmmError::CreateVmFailed)?;
 
         // Map memory.
-        vm.vm_map(
-            ram.host_addr().cast_mut().cast(),
-            ram.addr().try_into().unwrap(),
-            ram.len(),
-        )
-        .map_err(VmmError::MapRamFailed)?;
+        vm.vm_map(ram.host_addr().cast_mut().cast(), 0, ram.len())
+            .map_err(VmmError::MapRamFailed)?;
 
         Ok(Self { vm, ram })
     }

--- a/src/core/src/vmm/hv/windows/mod.rs
+++ b/src/core/src/vmm/hv/windows/mod.rs
@@ -28,12 +28,8 @@ impl Whp {
         part.setup().map_err(VmmError::SetupPartitionFailed)?;
 
         // Map memory.
-        part.map_gpa(
-            ram.host_addr().cast(),
-            ram.addr().try_into().unwrap(),
-            ram.len().try_into().unwrap(),
-        )
-        .map_err(VmmError::MapRamFailed)?;
+        part.map_gpa(ram.host_addr().cast(), 0, ram.len().try_into().unwrap())
+            .map_err(VmmError::MapRamFailed)?;
 
         Ok(Self { part, ram })
     }

--- a/src/core/src/vmm/hw/mod.rs
+++ b/src/core/src/vmm/hw/mod.rs
@@ -10,14 +10,12 @@ pub use self::ram::*;
 mod console;
 mod ram;
 
-pub(crate) const PAGE_SIZE: NonZero<usize> = unsafe { NonZero::new_unchecked(0x4000) };
-
-pub fn setup_devices(start_addr: usize) -> DeviceTree {
+pub fn setup_devices(start_addr: usize, vm_page_size: NonZero<usize>) -> DeviceTree {
     let mut map = BTreeMap::<usize, Arc<dyn Device>>::new();
 
     // Console.
     let addr = start_addr;
-    let console = Arc::new(Console::new(addr));
+    let console = Arc::new(Console::new(addr, vm_page_size));
 
     assert!(map.insert(console.addr(), console.clone()).is_none());
 

--- a/src/core/src/vmm/mod.rs
+++ b/src/core/src/vmm/mod.rs
@@ -529,7 +529,7 @@ fn get_page_size() -> Result<NonZero<usize>, std::io::Error> {
     if v < 0 {
         Err(std::io::Error::last_os_error())
     } else {
-        Ok(NonZero::new(v.try_into().unwrap()).unwrap())
+        Ok(v.try_into().ok().and_then(NonZero::new).unwrap())
     }
 }
 
@@ -541,7 +541,7 @@ fn get_page_size() -> Result<NonZero<usize>, std::io::Error> {
 
     unsafe { GetSystemInfo(&mut i) };
 
-    Ok(NonZero::new(i.dwPageSize.try_into().unwrap()))
+    Ok(i.dwPageSize.try_into().ok().and_then(NonZero::new).unwrap())
 }
 
 /// Manage a virtual machine that run the kernel.


### PR DESCRIPTION
Let the kernel use native page size supported by the CPU then emulate the PS4 page size within the kernel itself should be better. The benefit of this way is the kernel can run other binaries with different page size.