### PR TITLE
Uses 16K page on AArch64

### DIFF
--- a/src/obkrnl/build.rs
+++ b/src/obkrnl/build.rs
@@ -4,7 +4,7 @@ fn main() {
     match target.as_str() {
         "aarch64-unknown-none-softfloat" => {
             println!("cargo::rustc-link-arg-bins=--pie");
-            println!("cargo::rustc-link-arg-bins=-zmax-page-size=0x1000");
+            println!("cargo::rustc-link-arg-bins=-zmax-page-size=0x4000");
         }
         "x86_64-unknown-none" => {
             println!("cargo::rustc-link-arg-bins=-zmax-page-size=0x1000");

--- a/src/obkrnl/src/config/aarch64.rs
+++ b/src/obkrnl/src/config/aarch64.rs
@@ -1,1 +1,1 @@
-pub const PAGE_SIZE: usize = 0x1000;
+pub const PAGE_SIZE: usize = 0x4000;


### PR DESCRIPTION
Otherwise RAM allocation will fails on Mac M1 because it use 16K page. This will also works on other AArch64 systems that uses 16K page or lower.