### PR TITLE
Sets TCR_EL1.TnSZ to 48-bit virtual addresses

### DIFF
--- a/src/core/src/vmm/hv/mod.rs
+++ b/src/core/src/vmm/hv/mod.rs
@@ -87,6 +87,11 @@ pub trait CpuStates {
     #[cfg(target_arch = "x86_64")]
     fn set_ss(&mut self, p: bool);
 
+    /// # Panics
+    /// If `t0sz` or `t1sz` larger than 6 bits.
+    #[cfg(target_arch = "aarch64")]
+    fn set_tcr_el1(&mut self, t0sz: u8, t1sz: u8);
+
     #[cfg(target_arch = "aarch64")]
     fn set_sp_el1(&mut self, v: usize);
 

--- a/src/core/src/vmm/mod.rs
+++ b/src/core/src/vmm/mod.rs
@@ -553,6 +553,9 @@ fn setup_main_cpu(cpu: &mut impl Cpu, entry: usize, map: RamMap) -> Result<(), M
         .states()
         .map_err(|e| MainCpuError::GetCpuStatesFailed(Box::new(e)))?;
 
+    // Uses 48-bit virtual addresses (64 - 16 = 48) for both kernel space and user space.
+    states.set_tcr_el1(16, 16);
+
     // Set stack pointer to the kernel.
     states.set_sp_el1(map.stack_vaddr + map.stack_len); // Top-down.
 


### PR DESCRIPTION
See https://developer.arm.com/documentation/101811/0103/Address-spaces/Size-of-virtual-addresses for how it works.