### PR TITLE
Makes RAM belong to hypervisor

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -170,42 +170,6 @@ struct Vmm *vmm_run(const char *kernel,
 
 struct RustError *vmm_draw(struct Vmm *vmm);
 
-#if defined(__linux__)
-extern int kvm_check_version(int kvm, bool *compat);
-#endif
-
-#if defined(__linux__)
-extern int kvm_max_vcpus(int kvm, size_t *max);
-#endif
-
-#if defined(__linux__)
-extern int kvm_create_vm(int kvm, int *fd);
-#endif
-
-#if defined(__linux__)
-extern int kvm_get_vcpu_mmap_size(int kvm);
-#endif
-
-#if defined(__linux__)
-extern int kvm_set_user_memory_region(int vm,
-                                      uint32_t slot,
-                                      uint64_t addr,
-                                      uint64_t len,
-                                      void *mem);
-#endif
-
-#if defined(__linux__)
-extern int kvm_create_vcpu(int vm, uint32_t id, int *fd);
-#endif
-
-#if defined(__linux__)
-extern int kvm_run(int vcpu);
-#endif
-
-#if defined(__linux__)
-extern int kvm_translate(int vcpu, kvm_translation *arg);
-#endif
-
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/src/core/src/vmm/aarch64.rs
+++ b/src/core/src/vmm/aarch64.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use super::hv::{Cpu, CpuFeats, CpuStates, Pstate};
-use super::hw::RamMap;
+use super::ram::RamMap;
 use super::MainCpuError;
 
 pub fn setup_main_cpu(

--- a/src/core/src/vmm/hw/console/mod.rs
+++ b/src/core/src/vmm/hw/console/mod.rs
@@ -1,5 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
 use self::context::Context;
-use super::{Device, DeviceContext, Ram};
+use super::{Device, DeviceContext};
+use crate::vmm::hv::Hypervisor;
 use crate::vmm::VmmEventHandler;
 use obvirt::console::Memory;
 use std::num::NonZero;
@@ -26,7 +28,7 @@ impl Console {
     }
 }
 
-impl Device for Console {
+impl<H: Hypervisor> Device<H> for Console {
     fn addr(&self) -> usize {
         self.addr
     }
@@ -35,7 +37,7 @@ impl Device for Console {
         self.len
     }
 
-    fn create_context<'a>(&'a self, ram: &'a Ram) -> Box<dyn DeviceContext + 'a> {
-        Box::new(Context::new(self, ram))
+    fn create_context<'a>(&'a self, hv: &'a H) -> Box<dyn DeviceContext + 'a> {
+        Box::new(Context::new(self, hv))
     }
 }

--- a/src/core/src/vmm/x86_64.rs
+++ b/src/core/src/vmm/x86_64.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use super::hv::{Cpu, CpuFeats, CpuStates};
-use super::hw::RamMap;
+use super::ram::RamMap;
 use super::MainCpuError;
 
 pub fn setup_main_cpu(


### PR DESCRIPTION
So we can construct a hypervisor before RAM setup. The reason we need a hypervisor before setup a RAM is because we need a list of vCPU features on AArch64 to setup it correctly.

@SuchAFuriousDeath this also need an approval from you to relicense the files that contains your works.