### PR TITLE
Fixes create CPU fails on Linux AArch64

### DIFF
--- a/src/core/src/vmm/hv/aarch64.rs
+++ b/src/core/src/vmm/hv/aarch64.rs
@@ -2,6 +2,7 @@
 use bitfield_struct::bitfield;
 
 /// Features available on a PE.
+#[derive(Clone)]
 pub struct CpuFeats {
     /// Raw value of `ID_AA64MMFR0_EL1`.
     pub mmfr0: Mmfr0,

--- a/src/core/src/vmm/hv/linux/cpu.rs
+++ b/src/core/src/vmm/hv/linux/cpu.rs
@@ -5,28 +5,23 @@ use super::run::KvmRun;
 use crate::vmm::hv::{Cpu, CpuExit, CpuIo, IoBuf};
 use libc::munmap;
 use std::error::Error;
-use std::marker::PhantomData;
 use std::os::fd::{AsRawFd, OwnedFd};
+use std::sync::MutexGuard;
 
 /// Implementation of [`Cpu`] for KVM.
 pub struct KvmCpu<'a> {
-    fd: OwnedFd,
+    fd: MutexGuard<'a, OwnedFd>,
     cx: (*mut KvmRun, usize),
-    vm: PhantomData<&'a OwnedFd>,
 }
 
 impl<'a> KvmCpu<'a> {
     /// # Safety
     /// - `cx` cannot be null and must be obtained from `mmap` on `fd`.
     /// - `len` must be the same value that used on `mmap`.
-    pub unsafe fn new(fd: OwnedFd, cx: *mut KvmRun, len: usize) -> Self {
+    pub unsafe fn new(fd: MutexGuard<'a, OwnedFd>, cx: *mut KvmRun, len: usize) -> Self {
         assert!(len >= size_of::<KvmRun>());
 
-        Self {
-            fd,
-            cx: (cx, len),
-            vm: PhantomData,
-        }
+        Self { fd, cx: (cx, len) }
     }
 }
 

--- a/src/core/src/vmm/mod.rs
+++ b/src/core/src/vmm/mod.rs
@@ -722,6 +722,26 @@ enum VmmError {
     MapRamFailed(#[source] std::io::Error),
 
     #[cfg(target_os = "linux")]
+    #[error("couldn't create vCPU #{0}")]
+    CreateCpuFailed(usize, #[source] std::io::Error),
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[error("couldn't initialize vCPU #{0}")]
+    InitCpuFailed(usize, #[source] std::io::Error),
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[error("couldn't read ID_AA64MMFR0_EL1")]
+    ReadMmfr0Failed(#[source] std::io::Error),
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[error("couldn't read ID_AA64MMFR1_EL1")]
+    ReadMmfr1Failed(#[source] std::io::Error),
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[error("couldn't read ID_AA64MMFR2_EL1")]
+    ReadMmfr2Failed(#[source] std::io::Error),
+
+    #[cfg(target_os = "linux")]
     #[error("couldn't get the size of vCPU mmap")]
     GetMmapSizeFailed(#[source] std::io::Error),
 


### PR DESCRIPTION
If we reuse the same CPU ID that was created during feature query the KVM will return `EEXIST`. So we need to create all CPU upfront. This also fix the `KVM_ARM_VCPU_INIT` require all CPU to be created before executing it.