### PR TITLE
Initializes trap handler

### DIFF
--- a/gui/build.rs
+++ b/gui/build.rs
@@ -8,8 +8,7 @@ const LINUX_INCLUDE: &str = r#"
 "#;
 
 fn main() {
-    let core = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    let root = core.parent().unwrap();
+    let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let mut conf = Config::default();
     let mut buf = String::new();
 
@@ -47,9 +46,9 @@ fn main() {
         .insert("target_os = macos".into(), "__APPLE__".into());
 
     Builder::new()
-        .with_crate(&core)
+        .with_crate(&root)
         .with_config(conf)
         .generate()
         .unwrap()
-        .write_to_file(root.join("src").join("core.h"));
+        .write_to_file(root.join("core.h"));
 }

--- a/kernel/src/context/x86_64.rs
+++ b/kernel/src/context/x86_64.rs
@@ -37,15 +37,15 @@ pub unsafe fn activate(cx: *mut Context) {
 }
 
 pub unsafe fn thread() -> *const Thread {
-    // SAFETY: "AtomicPtr<Thread>" is guarantee to have the same bit as "*mut Thread" and "mov" is
-    // atomic if the memory has correct alignment.
+    // SAFETY: "mov" is atomic if the memory has correct alignment. We can use "nomem" here since
+    // the value never changed.
     let mut td;
 
     asm!(
         "mov {out}, gs:[{off}]",
         off = in(reg) offset_of!(Context, thread), // TODO: Use const from Rust 1.82.
         out = out(reg) td,
-        options(pure, readonly, preserves_flags, nostack)
+        options(pure, nomem, preserves_flags, nostack)
     );
 
     td

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -22,6 +22,7 @@ mod malloc;
 mod panic;
 mod proc;
 mod sched;
+mod trap;
 mod uma;
 
 extern crate alloc;

--- a/kernel/src/trap/aarch64.rs
+++ b/kernel/src/trap/aarch64.rs
@@ -1,0 +1,10 @@
+/// Main entry point for interrupt.
+///
+/// This will be called by an inline assembly.
+pub extern "C" fn interrupt_handler(_: &mut TrapFrame) {
+    todo!()
+}
+
+/// Contains states of the interupted program.
+#[repr(C)]
+pub struct TrapFrame {}

--- a/kernel/src/trap/mod.rs
+++ b/kernel/src/trap/mod.rs
@@ -1,0 +1,6 @@
+pub use self::arch::*;
+
+#[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
+#[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
+mod arch;
+mod vm;

--- a/kernel/src/trap/vm.rs
+++ b/kernel/src/trap/vm.rs
@@ -1,0 +1,14 @@
+use super::TrapFrame;
+use core::hint::unreachable_unchecked;
+use core::ptr::{addr_of_mut, write_volatile};
+use obconf::{KernelExit, Vm, VmmMemory};
+
+/// # Interupt safety
+/// This function can be called from interupt handler.
+pub fn interrupt_handler(env: &Vm, _: &mut TrapFrame) {
+    // TODO: Implement a virtual device with GDB stub.
+    let vmm = env.vmm as *mut VmmMemory;
+
+    unsafe { write_volatile(addr_of_mut!((*vmm).shutdown), KernelExit::Panic) };
+    unsafe { unreachable_unchecked() };
+}

--- a/kernel/src/trap/x86_64.rs
+++ b/kernel/src/trap/x86_64.rs
@@ -1,0 +1,46 @@
+use crate::config::boot_env;
+use obconf::BootEnv;
+
+/// Main entry point for interrupt.
+///
+/// This will be called by an inline assembly.
+///
+/// See `trap` function on the PS4 for a reference.
+pub extern "C" fn interrupt_handler(frame: &mut TrapFrame) {
+    match frame.num {
+        TrapNo::Breakpoint => match boot_env() {
+            BootEnv::Vm(vm) => super::vm::interrupt_handler(vm, frame),
+        },
+    }
+}
+
+/// Predefined interrupt vector number.
+#[allow(dead_code)] // Used by inline assembly.
+#[repr(u32)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TrapNo {
+    Breakpoint = 3, // T_BPTFLT
+}
+
+/// Contains states of the interupted program.
+#[repr(C)]
+pub struct TrapFrame {
+    pub rdi: usize,  // tf_rdi
+    pub rsi: usize,  // tf_rsi
+    pub rdx: usize,  // tf_rdx
+    pub rcx: usize,  // tf_rcx
+    pub r8: usize,   // tf_r8
+    pub r9: usize,   // tf_r9
+    pub rax: usize,  // tf_rax
+    pub rbx: usize,  // tf_rbx
+    pub rbp: usize,  // tf_rbp
+    pub r10: usize,  // tf_r10
+    pub r11: usize,  // tf_r11
+    pub r12: usize,  // tf_r12
+    pub r13: usize,  // tf_r13
+    pub r14: usize,  // tf_r14
+    pub r15: usize,  // tf_r15
+    pub num: TrapNo, // tf_trapno
+    pub fs: u16,     // tf_fs
+    pub gs: u16,     // tf_gs
+}


### PR DESCRIPTION
Now we have a working `int3` handler! The next step is implement a GDB stub on the VMM side so we can debug the kernel.