### PR TITLE
Update from macos-12 to macos-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/ci-mac.yml
     with:
       name: Mac Intel
-      macos: macos-12
+      macos: macos-13
       kernel-target: x86_64-unknown-none
       artifact-name: obliteration-mac-intel
   build-mac-m1:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,7 +27,7 @@ jobs:
     needs: prebuild
     with:
       name: Mac Intel
-      macos: macos-12
+      macos: macos-13
       kernel-target: x86_64-unknown-none
       artifact-name: obliteration-mac-intel
   build-mac-m1:


### PR DESCRIPTION
This is due to macos-12 soon being deprecated: https://github.com/actions/runner-images/issues/10721

As such, I bumped our runners that are using macos-12 to macos-13. Not macos-14, as that is an ARM64 based runner as shown here:
```
macOS 13	macos-13 or macos-13-large	macOS-13
macOS 13 Arm64	macos-13-xlarge			macOS-13-arm64
```
As long as macos-13 is used and not macos-13-xlarge, we'll stay on the intel platform.