### PR TITLE
Uses blocking-mode debug server

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # External dependencies.
-find_package(Qt6 REQUIRED COMPONENTS Network Svg Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Svg Widgets)
 find_package(Threads REQUIRED)
 
 if(WIN32 OR (UNIX AND NOT APPLE))
@@ -64,7 +64,7 @@ endif()
 
 target_compile_features(obliteration PRIVATE cxx_std_17)
 
-target_link_libraries(obliteration PRIVATE Qt6::Network Qt6::Svg Qt6::Widgets)
+target_link_libraries(obliteration PRIVATE Qt6::Svg Qt6::Widgets)
 target_link_libraries(obliteration PRIVATE Threads::Threads)
 target_link_libraries(obliteration PRIVATE ${LIBGUI})
 

--- a/gui/core.hpp
+++ b/gui/core.hpp
@@ -51,6 +51,13 @@ public:
 
     T *get() const { return m_ptr; }
     void free();
+
+    T *release()
+    {
+        auto p = m_ptr;
+        m_ptr = nullptr;
+        return p;
+    }
 private:
     T *m_ptr;
 };
@@ -60,6 +67,24 @@ inline void Rust<char>::free()
 {
     ::free(m_ptr);
     m_ptr = nullptr;
+}
+
+template<>
+inline void Rust<Debugger>::free()
+{
+    if (m_ptr) {
+        debugger_free(m_ptr);
+        m_ptr = nullptr;
+    }
+}
+
+template<>
+inline void Rust<DebugServer>::free()
+{
+    if (m_ptr) {
+        debug_server_free(m_ptr);
+        m_ptr = nullptr;
+    }
 }
 
 template<>

--- a/gui/main_window.hpp
+++ b/gui/main_window.hpp
@@ -2,15 +2,12 @@
 
 #include "core.hpp"
 
-#include <QAbstractSocket>
 #include <QList>
 #include <QMainWindow>
 #include <QPointer>
 #ifndef __APPLE__
 #include <QVulkanInstance>
 #endif
-
-#include <optional>
 
 class GameListModel;
 class LaunchSettings;
@@ -19,7 +16,6 @@ class ProfileList;
 class QCommandLineOption;
 class QCommandLineParser;
 class QStackedWidget;
-class QTcpSocket;
 class Screen;
 
 class MainWindow final : public QMainWindow {
@@ -38,7 +34,7 @@ public:
     bool loadGames();
     void restoreGeometry();
     void startDebug(const QString &addr);
-    void startVmm();
+    void startVmm(Debugger *d);
 protected:
     void closeEvent(QCloseEvent *event) override;
 private slots:
@@ -50,17 +46,16 @@ private slots:
     void saveProfile(Profile *p);
     void updateScreen();
 private:
+    void acceptDebuggerFailed(const QString &msg);
     void vmmError(const QString &msg);
     void waitKernelExit(bool success);
     void log(VmmLog type, const QString &msg);
     void breakpoint(KernelStop *stop);
-    std::optional<QAbstractSocket::SocketError> sendDebug(const uint8_t *data, size_t len);
     bool loadGame(const QString &gameId);
     bool requireVmmStopped();
     void killVmm();
 
     static void vmmHandler(const VmmEvent *ev, void *cx);
-    static bool sendDebug(void *cx, const uint8_t *data, size_t len, int *err);
 
     const QCommandLineParser &m_args;
     QStackedWidget *m_main;
@@ -69,7 +64,7 @@ private:
     LaunchSettings *m_launch;
     Screen *m_screen;
     QPointer<LogsViewer> m_logs;
-    QTcpSocket *m_debug;
+    Rust<DebugServer> m_debug;
     Rust<Vmm> m_vmm; // Destroy first.
 };
 

--- a/gui/src/debug/mod.rs
+++ b/gui/src/debug/mod.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::error::RustError;
+use std::ffi::{c_char, c_void, CStr, CString};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{sleep, JoinHandle};
+use std::time::Duration;
+
+#[no_mangle]
+pub unsafe extern "C" fn debug_server_start(
+    cx: *mut c_void,
+    addr: *const c_char,
+    err: *mut *mut RustError,
+    cb: unsafe extern "C" fn(&DebuggerAccept, *mut c_void),
+) -> *mut DebugServer {
+    // Get address.
+    let addr = match CStr::from_ptr(addr).to_str() {
+        Ok(v) => v,
+        Err(_) => {
+            *err = RustError::new("the specified address is not UTF-8").into_c();
+            return null_mut();
+        }
+    };
+
+    // Start server.
+    let sock = match TcpListener::bind(addr) {
+        Ok(v) => v,
+        Err(e) => {
+            *err = RustError::with_source("couldn't bind to the specified address", e).into_c();
+            return null_mut();
+        }
+    };
+
+    // Enable non-blocking mode so the GUI can cancel listening thread.
+    if let Err(e) = sock.set_nonblocking(true) {
+        *err = RustError::with_source("couldn't enable non-blocking mode", e).into_c();
+        return null_mut();
+    }
+
+    // Get effective address to let the user know.
+    let addr = match sock.local_addr() {
+        Ok(v) => CString::new(v.to_string()).unwrap(),
+        Err(e) => {
+            *err = RustError::with_source("couldn't get server address", e).into_c();
+            return null_mut();
+        }
+    };
+
+    // Start thread to wait for a connection.
+    let stop = Arc::new(AtomicBool::new(false));
+    let listener = std::thread::spawn({
+        let cx = cx as usize;
+        let stop = stop.clone();
+
+        move || {
+            while !stop.load(Ordering::Relaxed) {
+                let r = match sock.accept() {
+                    Ok((sock, _)) => DebuggerAccept::Ok {
+                        debugger: Box::into_raw(Box::new(Debugger {
+                            sock,
+                            buf: Vec::new(),
+                            next: 0,
+                        })),
+                    },
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        sleep(Duration::from_millis(500));
+                        continue;
+                    }
+                    Err(e) => DebuggerAccept::Err {
+                        reason: RustError::wrap(e).into_c(),
+                    },
+                };
+
+                cb(&r, cx as _);
+                break;
+            }
+        }
+    });
+
+    // Return server object.
+    let s = DebugServer {
+        addr,
+        listener: Some(listener),
+        stop,
+    };
+
+    Box::into_raw(s.into())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn debug_server_free(s: *mut DebugServer) {
+    drop(Box::from_raw(s));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn debug_server_addr(s: *mut DebugServer) -> *const c_char {
+    (*s).addr.as_ptr()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn debugger_free(d: *mut Debugger) {
+    drop(Box::from_raw(d));
+}
+
+/// TCP listener to accept a debugger connection.
+pub struct DebugServer {
+    addr: CString,
+    listener: Option<JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+}
+
+impl Drop for DebugServer {
+    fn drop(&mut self) {
+        // There are a small chance for memory leak if the listener thread queue the even to Qt
+        // event loop when are are here but it is okay since the only cases the Qt will miss that
+        // event is when it is being shutdown.
+        self.stop.store(true, Ordering::Relaxed);
+        self.listener.take().unwrap().join().unwrap();
+    }
+}
+
+/// Status of debugger connection acception.
+#[allow(dead_code)]
+#[repr(C)]
+pub enum DebuggerAccept {
+    Ok { debugger: *mut Debugger },
+    Err { reason: *mut RustError },
+}
+
+/// Encapsulate a debugger connection.
+pub struct Debugger {
+    sock: TcpStream,
+    buf: Vec<u8>,
+    next: usize,
+}
+
+impl Debugger {
+    pub fn read(&mut self) -> Result<u8, std::io::Error> {
+        // Fill the buffer if needed.
+        while self.next == self.buf.len() {
+            use std::io::ErrorKind;
+
+            // Clear previous data.
+            self.buf.clear();
+            self.next = 0;
+
+            // Read.
+            let mut buf = [0; 1024];
+            let len = match self.sock.read(&mut buf) {
+                Ok(v) => v,
+                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            };
+
+            if len == 0 {
+                return Err(std::io::Error::from(ErrorKind::UnexpectedEof));
+            }
+
+            self.buf.extend_from_slice(&buf[..len]);
+        }
+
+        // Get byte.
+        let b = self.buf[self.next];
+
+        self.next += 1;
+
+        Ok(b)
+    }
+}
+
+impl gdbstub::conn::Connection for Debugger {
+    type Error = std::io::Error;
+
+    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
+        Write::write_all(&mut self.sock, std::slice::from_ref(&byte))
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        Write::write_all(&mut self.sock, buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Write::flush(&mut self.sock)
+    }
+
+    fn on_session_start(&mut self) -> Result<(), Self::Error> {
+        self.sock.set_nodelay(true)
+    }
+}

--- a/gui/src/lib.rs
+++ b/gui/src/lib.rs
@@ -1,5 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
 use std::ffi::{c_char, c_void};
 
+mod debug;
 mod error;
 mod param;
 mod pkg;

--- a/gui/src/vmm/debug/mod.rs
+++ b/gui/src/vmm/debug/mod.rs
@@ -1,50 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pub use self::arch::*;
 
-use gdbstub::conn::Connection;
-use std::ffi::{c_int, c_void};
-
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
 #[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
 mod arch;
-
-/// Encapsulates a C++ function on Qt side to provide [`Connection`] implementation.
-pub struct Client {
-    fp: unsafe extern "C" fn(*mut c_void, *const u8, usize, *mut c_int) -> bool,
-    cx: *mut c_void,
-}
-
-impl Client {
-    pub fn new(
-        fp: unsafe extern "C" fn(*mut c_void, *const u8, usize, *mut c_int) -> bool,
-        cx: *mut c_void,
-    ) -> Self {
-        Self { fp, cx }
-    }
-}
-
-impl Connection for Client {
-    type Error = c_int;
-
-    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
-        self.write_all(std::slice::from_ref(&byte))
-    }
-
-    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
-        let mut e = 0;
-
-        if unsafe { (self.fp)(self.cx, buf.as_ptr(), buf.len(), &mut e) } {
-            Ok(())
-        } else {
-            Err(e)
-        }
-    }
-
-    fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn on_session_start(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-}


### PR DESCRIPTION
There is a problem with `QCoreApplication::processEvents` in our current code. The `QCoreApplication::processEvents` will also dispatch other Qt events, which mean if the other CPU already queued a debug event it will also get processed. That mean there will be another call to `vmm_dispatch_debug` while the previous one not finished yet.