### PR TITLE
Implements xmm and fpu internal reg getters

### DIFF
--- a/gui/src/vmm/cpu/mod.rs
+++ b/gui/src/vmm/cpu/mod.rs
@@ -271,7 +271,7 @@ impl<H: Hypervisor, S: Screen> CpuManager<H, S> {
 
     #[cfg(target_arch = "x86_64")]
     fn get_debug_regs<C: CpuStates>(states: &mut C) -> Result<GdbRegs, RustError> {
-        use gdbstub_arch::x86::reg::X86SegmentRegs;
+        use gdbstub_arch::x86::reg::{X86SegmentRegs, X87FpuInternalRegs};
 
         let error = |n: &str, e: C::Err| RustError::with_source(format!("couldn't get {n}"), e);
         let mut load_greg = |name: &str, func: fn(&mut C) -> Result<usize, C::Err>| {
@@ -322,8 +322,34 @@ impl<H: Hypervisor, S: Screen> CpuManager<H, S> {
                 states.get_st6().map_err(|e| error("st6", e))?,
                 states.get_st7().map_err(|e| error("st7", e))?,
             ],
-            fpu: todo!(),
-            xmm: todo!(),
+            fpu: X87FpuInternalRegs {
+                fctrl: states.get_fcw().map_err(|e| error("fcw", e))?,
+                fstat: states.get_fsw().map_err(|e| error("fsw", e))?,
+                ftag: states.get_ftwx().map_err(|e| error("ftwx", e))?,
+                fiseg: states.get_fiseg().map_err(|e| error("fiseg", e))?,
+                fioff: states.get_fioff().map_err(|e| error("fioff", e))?,
+                foseg: states.get_fiseg().map_err(|e| error("foseg", e))?,
+                fooff: states.get_fioff().map_err(|e| error("fooff", e))?,
+                fop: states.get_fop().map_err(|e| error("fop", e))?,
+            },
+            xmm: [
+                states.get_xmm0().map_err(|e| error("xmm0", e))?,
+                states.get_xmm1().map_err(|e| error("xmm1", e))?,
+                states.get_xmm2().map_err(|e| error("xmm2", e))?,
+                states.get_xmm3().map_err(|e| error("xmm3", e))?,
+                states.get_xmm4().map_err(|e| error("xmm4", e))?,
+                states.get_xmm5().map_err(|e| error("xmm5", e))?,
+                states.get_xmm6().map_err(|e| error("xmm6", e))?,
+                states.get_xmm7().map_err(|e| error("xmm7", e))?,
+                states.get_xmm8().map_err(|e| error("xmm8", e))?,
+                states.get_xmm9().map_err(|e| error("xmm9", e))?,
+                states.get_xmm10().map_err(|e| error("xmm10", e))?,
+                states.get_xmm11().map_err(|e| error("xmm11", e))?,
+                states.get_xmm12().map_err(|e| error("xmm12", e))?,
+                states.get_xmm13().map_err(|e| error("xmm13", e))?,
+                states.get_xmm14().map_err(|e| error("xmm14", e))?,
+                states.get_xmm15().map_err(|e| error("xmm15", e))?,
+            ],
             mxcsr: todo!(),
         })
     }

--- a/gui/src/vmm/cpu/mod.rs
+++ b/gui/src/vmm/cpu/mod.rs
@@ -350,7 +350,7 @@ impl<H: Hypervisor, S: Screen> CpuManager<H, S> {
                 states.get_xmm14().map_err(|e| error("xmm14", e))?,
                 states.get_xmm15().map_err(|e| error("xmm15", e))?,
             ],
-            mxcsr: todo!(),
+            mxcsr: states.get_mxcsr().map_err(|e| error("mxcsr", e))?,
         })
     }
 

--- a/gui/src/vmm/hv/linux/cpu.rs
+++ b/gui/src/vmm/hv/linux/cpu.rs
@@ -35,9 +35,15 @@ impl<'a> Drop for KvmCpu<'a> {
 }
 
 impl<'a> Cpu for KvmCpu<'a> {
-    type States<'b> = KvmStates<'b> where Self: 'b;
+    type States<'b>
+        = KvmStates<'b>
+    where
+        Self: 'b;
     type GetStatesErr = StatesError;
-    type Exit<'b> = KvmExit<'b, 'a> where Self: 'b;
+    type Exit<'b>
+        = KvmExit<'b, 'a>
+    where
+        Self: 'b;
 
     fn states(&mut self) -> Result<Self::States<'_>, Self::GetStatesErr> {
         KvmStates::from_cpu(&mut self.fd)

--- a/gui/src/vmm/hv/linux/x86_64.rs
+++ b/gui/src/vmm/hv/linux/x86_64.rs
@@ -276,19 +276,19 @@ impl<'a> CpuStates for KvmStates<'a> {
     }
 
     fn get_fiseg(&mut self) -> Result<u32, Self::Err> {
-        Ok((self.fregs.last_ip & 0xFFFFFFFF) as u32)
-    }
-
-    fn get_fioff(&mut self) -> Result<u32, Self::Err> {
         Ok(((self.fregs.last_ip >> 32) & 0xFFFF) as u32)
     }
 
+    fn get_fioff(&mut self) -> Result<u32, Self::Err> {
+        Ok((self.fregs.last_ip & 0xFFFFFFFF) as u32)
+    }
+
     fn get_foseg(&mut self) -> Result<u32, Self::Err> {
-        Ok((self.fregs.last_dp & 0xFFFFFFFF) as u32)
+        Ok(((self.fregs.last_dp >> 32) & 0xFFFF) as u32)
     }
 
     fn get_fooff(&mut self) -> Result<u32, Self::Err> {
-        Ok(((self.fregs.last_dp >> 32) & 0xFFFF) as u32)
+        Ok((self.fregs.last_dp & 0xFFFFFFFF) as u32)
     }
 
     fn get_fop(&mut self) -> Result<u32, Self::Err> {

--- a/gui/src/vmm/hv/linux/x86_64.rs
+++ b/gui/src/vmm/hv/linux/x86_64.rs
@@ -276,19 +276,19 @@ impl<'a> CpuStates for KvmStates<'a> {
     }
 
     fn get_fiseg(&mut self) -> Result<u32, Self::Err> {
-        Ok((self.fregs.last_ip >> 32) as u32)
-    }
-
-    fn get_fioff(&mut self) -> Result<u32, Self::Err> {
         Ok((self.fregs.last_ip & 0xFFFFFFFF) as u32)
     }
 
+    fn get_fioff(&mut self) -> Result<u32, Self::Err> {
+        Ok(((self.fregs.last_ip >> 32) & 0xFFFF) as u32)
+    }
+
     fn get_foseg(&mut self) -> Result<u32, Self::Err> {
-        Ok((self.fregs.last_dp >> 32) as u32)
+        Ok((self.fregs.last_dp & 0xFFFFFFFF) as u32)
     }
 
     fn get_fooff(&mut self) -> Result<u32, Self::Err> {
-        Ok((self.fregs.last_dp & 0xFFFFFFFF) as u32)
+        Ok(((self.fregs.last_dp >> 32) & 0xFFFF) as u32)
     }
 
     fn get_fop(&mut self) -> Result<u32, Self::Err> {

--- a/gui/src/vmm/hv/linux/x86_64.rs
+++ b/gui/src/vmm/hv/linux/x86_64.rs
@@ -262,6 +262,103 @@ impl<'a> CpuStates for KvmStates<'a> {
     fn get_st7(&mut self) -> Result<[u8; 10], Self::Err> {
         Ok(self.fregs.fpr[7][..10].try_into().unwrap())
     }
+
+    fn get_fcw(&mut self) -> Result<u32, Self::Err> {
+        Ok(self.fregs.fcw.into())
+    }
+
+    fn get_fsw(&mut self) -> Result<u32, Self::Err> {
+        Ok(self.fregs.fsw.into())
+    }
+
+    fn get_ftwx(&mut self) -> Result<u32, Self::Err> {
+        Ok(self.fregs.ftwx.into())
+    }
+
+    fn get_fiseg(&mut self) -> Result<u32, Self::Err> {
+        Ok((self.fregs.last_ip >> 32) as u32)
+    }
+
+    fn get_fioff(&mut self) -> Result<u32, Self::Err> {
+        Ok((self.fregs.last_ip & 0xFFFFFFFF) as u32)
+    }
+
+    fn get_foseg(&mut self) -> Result<u32, Self::Err> {
+        Ok((self.fregs.last_dp >> 32) as u32)
+    }
+
+    fn get_fooff(&mut self) -> Result<u32, Self::Err> {
+        Ok((self.fregs.last_dp & 0xFFFFFFFF) as u32)
+    }
+
+    fn get_fop(&mut self) -> Result<u32, Self::Err> {
+        Ok(self.fregs.last_opcode.into())
+    }
+
+    fn get_xmm0(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[0]))
+    }
+
+    fn get_xmm1(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[1]))
+    }
+
+    fn get_xmm2(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[2]))
+    }
+
+    fn get_xmm3(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[3]))
+    }
+
+    fn get_xmm4(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[4]))
+    }
+
+    fn get_xmm5(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[5]))
+    }
+
+    fn get_xmm6(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[6]))
+    }
+
+    fn get_xmm7(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[7]))
+    }
+
+    fn get_xmm8(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[8]))
+    }
+
+    fn get_xmm9(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[9]))
+    }
+
+    fn get_xmm10(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[10]))
+    }
+
+    fn get_xmm11(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[11]))
+    }
+
+    fn get_xmm12(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[12]))
+    }
+
+    fn get_xmm13(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[13]))
+    }
+
+    fn get_xmm14(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[14]))
+    }
+
+    fn get_xmm15(&mut self) -> Result<u128, Self::Err> {
+        Ok(u128::from_le_bytes(self.fregs.xmm[15]))
+    }
+
 }
 
 impl<'a> CpuCommit for KvmStates<'a> {

--- a/gui/src/vmm/hv/linux/x86_64.rs
+++ b/gui/src/vmm/hv/linux/x86_64.rs
@@ -358,7 +358,6 @@ impl<'a> CpuStates for KvmStates<'a> {
     fn get_xmm15(&mut self) -> Result<u128, Self::Err> {
         Ok(u128::from_le_bytes(self.fregs.xmm[15]))
     }
-
 }
 
 impl<'a> CpuCommit for KvmStates<'a> {

--- a/gui/src/vmm/hv/linux/x86_64.rs
+++ b/gui/src/vmm/hv/linux/x86_64.rs
@@ -358,6 +358,10 @@ impl<'a> CpuStates for KvmStates<'a> {
     fn get_xmm15(&mut self) -> Result<u128, Self::Err> {
         Ok(u128::from_le_bytes(self.fregs.xmm[15]))
     }
+
+    fn get_mxcsr(&mut self) -> Result<u32, Self::Err> {
+        Ok(self.fregs.mxcsr.into())
+    }
 }
 
 impl<'a> CpuCommit for KvmStates<'a> {

--- a/gui/src/vmm/hv/macos/cpu.rs
+++ b/gui/src/vmm/hv/macos/cpu.rs
@@ -41,9 +41,15 @@ impl<'a> Drop for HvfCpu<'a> {
 }
 
 impl<'a> Cpu for HvfCpu<'a> {
-    type States<'b> = HvfStates<'b, 'a> where Self: 'b;
+    type States<'b>
+        = HvfStates<'b, 'a>
+    where
+        Self: 'b;
     type GetStatesErr = StatesError;
-    type Exit<'b> = HvfExit<'b, 'a> where Self: 'b;
+    type Exit<'b>
+        = HvfExit<'b, 'a>
+    where
+        Self: 'b;
 
     fn states(&mut self) -> Result<Self::States<'_>, Self::GetStatesErr> {
         Ok(HvfStates {

--- a/gui/src/vmm/hv/windows/cpu.rs
+++ b/gui/src/vmm/hv/windows/cpu.rs
@@ -356,6 +356,102 @@ impl<'a, 'b> CpuStates for WhpStates<'a, 'b> {
     fn get_st7(&mut self) -> Result<[u8; 10], Self::Err> {
         todo!()
     }
+
+    fn get_fcw(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_fsw(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_ftwx(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_fiseg(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_fioff(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_foseg(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_fooff(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_fop(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm0(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm1(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm2(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm3(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm4(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm5(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm6(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm7(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm8(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm9(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm10(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm11(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm12(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm13(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm14(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
+
+    fn get_xmm15(&mut self) -> Result<u128, Self::Err> {
+        todo!()
+    }
 }
 
 impl<'a, 'b> CpuCommit for WhpStates<'a, 'b> {

--- a/gui/src/vmm/hv/windows/cpu.rs
+++ b/gui/src/vmm/hv/windows/cpu.rs
@@ -44,9 +44,15 @@ impl<'a> Drop for WhpCpu<'a> {
 }
 
 impl<'a> Cpu for WhpCpu<'a> {
-    type States<'b> = WhpStates<'b, 'a> where Self: 'b;
+    type States<'b>
+        = WhpStates<'b, 'a>
+    where
+        Self: 'b;
     type GetStatesErr = StatesError;
-    type Exit<'b> = WhpExit<'b, 'a> where Self: 'b;
+    type Exit<'b>
+        = WhpExit<'b, 'a>
+    where
+        Self: 'b;
 
     fn states(&mut self) -> Result<Self::States<'_>, Self::GetStatesErr> {
         let mut values: [WHV_REGISTER_VALUE; REGISTERS] = unsafe { zeroed() };

--- a/gui/src/vmm/hv/windows/cpu.rs
+++ b/gui/src/vmm/hv/windows/cpu.rs
@@ -458,6 +458,10 @@ impl<'a, 'b> CpuStates for WhpStates<'a, 'b> {
     fn get_xmm15(&mut self) -> Result<u128, Self::Err> {
         todo!()
     }
+
+    fn get_mxcsr(&mut self) -> Result<u32, Self::Err> {
+        todo!()
+    }
 }
 
 impl<'a, 'b> CpuCommit for WhpStates<'a, 'b> {

--- a/gui/src/vmm/hv/x86_64.rs
+++ b/gui/src/vmm/hv/x86_64.rs
@@ -80,6 +80,8 @@ pub trait CpuStates {
     fn get_xmm13(&mut self) -> Result<u128, Self::Err>;
     fn get_xmm14(&mut self) -> Result<u128, Self::Err>;
     fn get_xmm15(&mut self) -> Result<u128, Self::Err>;
+
+    fn get_mxcsr(&mut self) -> Result<u32, Self::Err>;
 }
 
 /// Features available on a CPU.

--- a/gui/src/vmm/hv/x86_64.rs
+++ b/gui/src/vmm/hv/x86_64.rs
@@ -80,7 +80,6 @@ pub trait CpuStates {
     fn get_xmm13(&mut self) -> Result<u128, Self::Err>;
     fn get_xmm14(&mut self) -> Result<u128, Self::Err>;
     fn get_xmm15(&mut self) -> Result<u128, Self::Err>;
-
 }
 
 /// Features available on a CPU.

--- a/gui/src/vmm/hv/x86_64.rs
+++ b/gui/src/vmm/hv/x86_64.rs
@@ -27,6 +27,7 @@ pub trait CpuStates {
     fn set_rsp(&mut self, v: usize);
     fn get_rip(&mut self) -> Result<usize, Self::Err>;
     fn set_rip(&mut self, v: usize);
+
     fn set_cr0(&mut self, v: usize);
     fn set_cr3(&mut self, v: usize);
     fn set_cr4(&mut self, v: usize);
@@ -44,6 +45,7 @@ pub trait CpuStates {
     fn set_gs(&mut self, p: bool);
     fn get_ss(&mut self) -> Result<u16, Self::Err>;
     fn set_ss(&mut self, p: bool);
+
     fn get_st0(&mut self) -> Result<[u8; 10], Self::Err>;
     fn get_st1(&mut self) -> Result<[u8; 10], Self::Err>;
     fn get_st2(&mut self) -> Result<[u8; 10], Self::Err>;
@@ -52,6 +54,33 @@ pub trait CpuStates {
     fn get_st5(&mut self) -> Result<[u8; 10], Self::Err>;
     fn get_st6(&mut self) -> Result<[u8; 10], Self::Err>;
     fn get_st7(&mut self) -> Result<[u8; 10], Self::Err>;
+
+    fn get_fcw(&mut self) -> Result<u32, Self::Err>;
+    fn get_fsw(&mut self) -> Result<u32, Self::Err>;
+    fn get_ftwx(&mut self) -> Result<u32, Self::Err>;
+    fn get_fiseg(&mut self) -> Result<u32, Self::Err>;
+    fn get_fioff(&mut self) -> Result<u32, Self::Err>;
+    fn get_foseg(&mut self) -> Result<u32, Self::Err>;
+    fn get_fooff(&mut self) -> Result<u32, Self::Err>;
+    fn get_fop(&mut self) -> Result<u32, Self::Err>;
+
+    fn get_xmm0(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm1(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm2(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm3(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm4(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm5(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm6(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm7(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm8(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm9(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm10(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm11(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm12(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm13(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm14(&mut self) -> Result<u128, Self::Err>;
+    fn get_xmm15(&mut self) -> Result<u128, Self::Err>;
+
 }
 
 /// Features available on a CPU.

--- a/gui/src/vmm/screen/vulkan/mod.rs
+++ b/gui/src/vmm/screen/vulkan/mod.rs
@@ -120,7 +120,7 @@ impl Screen for Vulkan {
     }
 
     fn update(&mut self) -> Result<(), Self::UpdateErr> {
-        todo!()
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I'm not sure about u128::from_le_bytes and how to name the getters for the internal fpu registers, the names in the Linux struct don't match the ones in the gdb_stub.

After adding mxcsr, we panic on read_registers.