### PR TITLE
Removes .obliteration-development

### DIFF
--- a/.obliteration-development
+++ b/.obliteration-development
@@ -1,1 +1,0 @@
-This file used for detection of development binary in src/main_window.cpp.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,10 @@
       "name": "GUI",
       "type": "lldb",
       "request": "launch",
-      "args": [],
+      "args": [
+        "--kernel",
+        "${workspaceFolder}/build/obkrnl"
+      ],
       "cwd": "${workspaceFolder}",
       "windows": {
         "program": "${workspaceFolder}/build/gui/Obliteration.exe",
@@ -25,35 +28,12 @@
       "request": "custom",
       "preLaunchTask": "Launch VMM (Debug)",
       "targetCreateCommands": [
-        "target create ${workspaceFolder}/target/x86_64-unknown-none/debug/obkrnl"
+        "target create ${workspaceFolder}/build/obkrnl",
+        "target modules load --file ${workspaceFolder}/build/obkrnl -s 0xffffffff82200000"
       ],
-      "osx": {
-        "targetCreateCommands": [
-          "target create ${workspaceFolder}/target/aarch64-unknown-none-softfloat/debug/obkrnl"
-        ]
-      },
       "processCreateCommands": [
         "gdb-remote 1234"
       ]
-    },
-    {
-      "name": "Legacy Kernel",
-      "type": "lldb",
-      "request": "launch",
-      "cargo": {
-        "args": [
-          "build",
-          "--manifest-path",
-          "${workspaceFolder}/src/kernel/Cargo.toml"
-        ],
-        "filter": {
-          "kind": "bin"
-        }
-      },
-      "args": [
-        "--debug"
-      ],
-      "cwd": "${workspaceFolder}"
     }
   ],
   "version": "2.0.0"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,9 @@
       },
       "args": [
         "--debug",
-        "127.0.0.1:1234"
+        "127.0.0.1:1234",
+        "--kernel",
+        "${workspaceFolder}/build/obkrnl"
       ]
     }
   ]

--- a/cmake/cargo.cmake
+++ b/cmake/cargo.cmake
@@ -144,7 +144,7 @@ function(add_crate crate)
     set(release_outputs "${outputs}/${triple}/release")
 
     if(${target_os} STREQUAL "windows")
-        set(bin_ext ".exe")
+        set(bin_suffix ".exe")
     endif()
 
     # Setup build arguments.
@@ -189,8 +189,8 @@ function(add_crate crate)
             continue()
         elseif(${kind} STREQUAL "bin")
             add_executable(${crate} IMPORTED)
-            set(debug_artifact "${debug_outputs}/${crate}${bin_ext}")
-            set(release_artifact "${release_outputs}/${crate}${bin_ext}")
+            set(debug_artifact "${debug_outputs}/${crate}${bin_suffix}")
+            set(release_artifact "${release_outputs}/${crate}${bin_suffix}")
         else()
             message(FATAL_ERROR "${kind} crate is not supported")
         endif()
@@ -206,9 +206,12 @@ function(add_crate crate)
             IMPORTED_LOCATION_RELEASE ${release_artifact})
 
         # Add build target.
+        set(output "$<IF:$<CONFIG:Debug>,${debug_artifact},${release_artifact}>")
+
         add_custom_target(${build_target}
             COMMAND cargo ${build_args}
+            COMMAND ${CMAKE_COMMAND} -E copy -t ${CMAKE_CURRENT_BINARY_DIR} ${output}
             WORKING_DIRECTORY ${working_directory}
-            BYPRODUCTS $<IF:$<CONFIG:Debug>,${debug_artifact},${release_artifact}>)
+            BYPRODUCTS ${output})
     endforeach()
 endfunction()

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
     args.setApplicationDescription("Virtualization stack for Obliteration");
     args.addHelpOption();
     args.addOption(Args::debug);
+    args.addOption(Args::kernel);
     args.process(app);
 
     // Hook Rust panic.

--- a/gui/main_window.cpp
+++ b/gui/main_window.cpp
@@ -43,6 +43,7 @@
 
 namespace Args {
     const QCommandLineOption debug("debug", "Immediate launch the VMM in debug mode.", "addr", "127.0.0.1:1234");
+    const QCommandLineOption kernel("kernel", "Use this kernel instead of default one.", "path");
 }
 
 #ifdef __APPLE__
@@ -642,25 +643,8 @@ void MainWindow::startVmm(Rust<DebugClient> &&debug)
 
     m_debugServer.free();
 
-    if (QFile::exists(".obliteration-development")) {
-        auto b = std::filesystem::current_path();
-#ifdef _WIN32
-        auto target = L"x86_64-unknown-none";
-#elif defined(__aarch64__)
-        auto target = "aarch64-unknown-none-softfloat";
-#else
-        auto target = "x86_64-unknown-none";
-#endif
-
-#if defined(_WIN32) && defined(NDEBUG)
-        kernel = (b / L"target" / target / L"release" / L"obkrnl").u8string();
-#elif defined(_WIN32) && !defined(NDEBUG)
-        kernel = (b / L"target" / target / L"debug" / L"obkrnl").u8string();
-#elif defined(NDEBUG)
-        kernel = (b / "target" / target / "release" / "obkrnl").u8string();
-#else
-        kernel = (b / "target" / target / "debug" / "obkrnl").u8string();
-#endif
+    if (m_args.isSet(Args::kernel)) {
+        kernel = m_args.value(Args::kernel).toStdString();
     } else {
 #ifdef _WIN32
         std::filesystem::path b(QCoreApplication::applicationDirPath().toStdString(), std::filesystem::path::native_format);

--- a/gui/main_window.hpp
+++ b/gui/main_window.hpp
@@ -74,4 +74,5 @@ private:
 
 namespace Args {
     extern const QCommandLineOption debug;
+    extern const QCommandLineOption kernel;
 }


### PR DESCRIPTION
With a little help from CMake now we can use the same kernel path on every platform.