### PR TITLE
Fixes hv_vcpu_run never return

### DIFF
--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -20,6 +20,8 @@ ciborium = "0.2.2"
 serde = { version = "1.0.209", features = ["derive"] }
 thiserror = "1.0"
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 x86-64 = { path = "../arch/x86-64" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]

--- a/gui/src/vmm/hv/linux/mapper.rs
+++ b/gui/src/vmm/hv/linux/mapper.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::vmm::hv::RamMapper;
+use std::num::NonZero;
+use thiserror::Error;
+
+/// Implementation of [`RamMapper`] for KVM.
+pub struct KvmMapper;
+
+impl RamMapper for KvmMapper {
+    type Err = KvmMapperError;
+
+    fn map(&self, _: *mut u8, _: usize, _: NonZero<usize>) -> Result<(), Self::Err> {
+        Ok(())
+    }
+}
+
+/// Implementation of [`RamMapper::Err`] for KVM.
+#[derive(Debug, Error)]
+pub enum KvmMapperError {}

--- a/gui/src/vmm/hv/linux/mod.rs
+++ b/gui/src/vmm/hv/linux/mod.rs
@@ -6,8 +6,7 @@ use self::ffi::{
     KVM_GET_API_VERSION, KVM_GET_VCPU_MMAP_SIZE, KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_USE_SW_BP,
     KVM_SET_GUEST_DEBUG, KVM_SET_USER_MEMORY_REGION,
 };
-use super::{CpuFeats, Hypervisor};
-use crate::vmm::ram::Ram;
+use super::{CpuFeats, Hypervisor, Ram};
 use libc::{ioctl, mmap, open, MAP_FAILED, MAP_PRIVATE, O_RDWR, PROT_READ, PROT_WRITE};
 use std::ffi::{c_int, c_uint};
 use std::io::Error;

--- a/gui/src/vmm/hv/linux/mod.rs
+++ b/gui/src/vmm/hv/linux/mod.rs
@@ -6,11 +6,13 @@ use self::ffi::{
     KVM_GET_API_VERSION, KVM_GET_VCPU_MMAP_SIZE, KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_USE_SW_BP,
     KVM_SET_GUEST_DEBUG, KVM_SET_USER_MEMORY_REGION,
 };
+use self::mapper::KvmMapper;
 use super::{CpuFeats, Hypervisor, Ram};
 use libc::{ioctl, mmap, open, MAP_FAILED, MAP_PRIVATE, O_RDWR, PROT_READ, PROT_WRITE};
 use std::ffi::{c_int, c_uint};
 use std::io::Error;
 use std::mem::zeroed;
+use std::num::NonZero;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use std::ptr::null_mut;
 use std::sync::Mutex;
@@ -21,9 +23,23 @@ use thiserror::Error;
 mod arch;
 mod cpu;
 mod ffi;
+mod mapper;
 mod run;
 
-pub fn new(cpu: usize, ram: Ram, debug: bool) -> Result<Kvm, KvmError> {
+/// Panics
+/// If `ram_size` is not multiply by `ram_block`.
+///
+/// # Safety
+/// `ram_block` must be greater or equal host page size.
+pub fn new(
+    cpu: usize,
+    ram_size: NonZero<usize>,
+    ram_block: NonZero<usize>,
+    debug: bool,
+) -> Result<Kvm, KvmError> {
+    // Create RAM.
+    let ram = Ram::new(ram_size, ram_block, KvmMapper).map_err(KvmError::CreateRamFailed)?;
+
     // Open KVM device.
     let kvm = unsafe { open("/dev/kvm\0".as_ptr().cast(), O_RDWR) };
 
@@ -310,12 +326,13 @@ pub struct Kvm {
     vcpu_mmap_size: usize,
     #[allow(dead_code)]
     vm: OwnedFd,
-    ram: Ram,
+    ram: Ram<KvmMapper>,
     #[allow(dead_code)] // kvm are needed by vm.
     kvm: OwnedFd,
 }
 
 impl Hypervisor for Kvm {
+    type Mapper = KvmMapper;
     type Cpu<'a> = KvmCpu<'a>;
     type CpuErr = KvmCpuError;
 
@@ -323,11 +340,11 @@ impl Hypervisor for Kvm {
         &self.feats
     }
 
-    fn ram(&self) -> &Ram {
+    fn ram(&self) -> &Ram<Self::Mapper> {
         &self.ram
     }
 
-    fn ram_mut(&mut self) -> &mut Ram {
+    fn ram_mut(&mut self) -> &mut Ram<Self::Mapper> {
         &mut self.ram
     }
 
@@ -359,6 +376,9 @@ impl Hypervisor for Kvm {
 /// Represents an error when [`Kvm`] fails to initialize.
 #[derive(Debug, Error)]
 pub enum KvmError {
+    #[error("couldn't create a RAM")]
+    CreateRamFailed(#[source] Error),
+
     #[error("couldn't open /dev/kvm")]
     OpenKvmFailed(#[source] Error),
 

--- a/gui/src/vmm/hv/linux/mod.rs
+++ b/gui/src/vmm/hv/linux/mod.rs
@@ -31,7 +31,7 @@ mod run;
 ///
 /// # Safety
 /// `ram_block` must be greater or equal host page size.
-pub fn new(
+pub unsafe fn new(
     cpu: usize,
     ram_size: NonZero<usize>,
     ram_block: NonZero<usize>,

--- a/gui/src/vmm/hv/macos/mapper.rs
+++ b/gui/src/vmm/hv/macos/mapper.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::vmm::hv::RamMapper;
+use applevisor_sys::{hv_return_t, hv_vm_map, HV_MEMORY_EXEC, HV_MEMORY_READ, HV_MEMORY_WRITE};
+use std::num::NonZero;
+use thiserror::Error;
+
+/// Implementation of [`RamMapper`] for Hypervisor Framework.
+pub struct HvfMapper;
+
+impl RamMapper for HvfMapper {
+    type Err = HvfMapperError;
+
+    fn map(&self, host: *mut u8, vm: usize, len: NonZero<usize>) -> Result<(), Self::Err> {
+        let ret = unsafe {
+            hv_vm_map(
+                host.cast(),
+                vm.try_into().unwrap(),
+                len.get(),
+                HV_MEMORY_READ | HV_MEMORY_WRITE | HV_MEMORY_EXEC,
+            )
+        };
+
+        match NonZero::new(ret) {
+            Some(ret) => Err(HvfMapperError::MapFailed(ret)),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Implementation of [`RamMapper::Err`] for Hypervisor Framework.
+#[derive(Debug, Error)]
+pub enum HvfMapperError {
+    #[error("hv_vm_map failed ({0:#x})")]
+    MapFailed(NonZero<hv_return_t>),
+}

--- a/gui/src/vmm/hv/macos/mod.rs
+++ b/gui/src/vmm/hv/macos/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use self::cpu::HvfCpu;
+use self::mapper::HvfMapper;
 use super::{CpuFeats, Hypervisor, Ram};
-use crate::vmm::VmmError;
 use applevisor_sys::hv_feature_reg_t::{
     HV_FEATURE_REG_ID_AA64MMFR0_EL1, HV_FEATURE_REG_ID_AA64MMFR1_EL1,
     HV_FEATURE_REG_ID_AA64MMFR2_EL1,
@@ -9,19 +9,33 @@ use applevisor_sys::hv_feature_reg_t::{
 use applevisor_sys::{
     hv_feature_reg_t, hv_return_t, hv_vcpu_config_create, hv_vcpu_config_get_feature_reg,
     hv_vcpu_config_t, hv_vcpu_create, hv_vcpu_set_trap_debug_exceptions, hv_vm_create,
-    hv_vm_destroy, hv_vm_map, HV_MEMORY_EXEC, HV_MEMORY_READ, HV_MEMORY_WRITE,
+    hv_vm_destroy,
 };
 use std::num::NonZero;
 use std::ptr::{null, null_mut};
 use thiserror::Error;
 
 mod cpu;
+mod mapper;
 
-pub fn new(_: usize, ram: Ram, debug: bool) -> Result<Hvf, VmmError> {
+/// Panics
+/// If `ram_size` is not multiply by `ram_block`.
+///
+/// # Safety
+/// `ram_block` must be greater or equal host page size.
+pub unsafe fn new(
+    _: usize,
+    ram_size: NonZero<usize>,
+    ram_block: NonZero<usize>,
+    debug: bool,
+) -> Result<Hvf, HvfError> {
+    // Create RAM.
+    let ram = Ram::new(ram_size, ram_block, HvfMapper).map_err(HvfError::CreateRamFailed)?;
+
     // Create a VM.
     let ret = unsafe { hv_vm_create(null_mut()) };
     let mut hv = match NonZero::new(ret) {
-        Some(ret) => return Err(VmmError::CreateVmFailed(ret)),
+        Some(ret) => return Err(HvfError::CreateVmFailed(ret)),
         None => Hvf {
             ram,
             debug,
@@ -33,38 +47,23 @@ pub fn new(_: usize, ram: Ram, debug: bool) -> Result<Hvf, VmmError> {
     // Load PE features.
     hv.feats.mmfr0 = hv
         .read_feature_reg(HV_FEATURE_REG_ID_AA64MMFR0_EL1)
-        .map_err(VmmError::ReadMmfr0Failed)?
+        .map_err(HvfError::ReadMmfr0Failed)?
         .into();
     hv.feats.mmfr1 = hv
         .read_feature_reg(HV_FEATURE_REG_ID_AA64MMFR1_EL1)
-        .map_err(VmmError::ReadMmfr1Failed)?
+        .map_err(HvfError::ReadMmfr1Failed)?
         .into();
     hv.feats.mmfr2 = hv
         .read_feature_reg(HV_FEATURE_REG_ID_AA64MMFR2_EL1)
-        .map_err(VmmError::ReadMmfr2Failed)?
+        .map_err(HvfError::ReadMmfr2Failed)?
         .into();
 
-    // Set RAM.
-    let host = hv.ram.host_addr().cast_mut().cast();
-    let len = hv.ram.len().get().try_into().unwrap();
-    let ret = unsafe {
-        hv_vm_map(
-            host,
-            0,
-            len,
-            HV_MEMORY_READ | HV_MEMORY_WRITE | HV_MEMORY_EXEC,
-        )
-    };
-
-    match NonZero::new(ret) {
-        Some(ret) => Err(VmmError::MapRamFailed(ret)),
-        None => Ok(hv),
-    }
+    Ok(hv)
 }
 
 /// Implementation of [`Hypervisor`] using Hypervisor Framework.
 pub struct Hvf {
-    ram: Ram,
+    ram: Ram<HvfMapper>,
     debug: bool,
     cpu_config: hv_vcpu_config_t,
     feats: CpuFeats,
@@ -97,6 +96,7 @@ impl Drop for Hvf {
 }
 
 impl Hypervisor for Hvf {
+    type Mapper = HvfMapper;
     type Cpu<'a> = HvfCpu<'a>;
     type CpuErr = HvfCpuError;
 
@@ -104,11 +104,11 @@ impl Hypervisor for Hvf {
         &self.feats
     }
 
-    fn ram(&self) -> &Ram {
+    fn ram(&self) -> &Ram<Self::Mapper> {
         &self.ram
     }
 
-    fn ram_mut(&mut self) -> &mut Ram {
+    fn ram_mut(&mut self) -> &mut Ram<Self::Mapper> {
         &mut self.ram
     }
 
@@ -137,6 +137,25 @@ impl Hypervisor for Hvf {
 
 unsafe impl Send for Hvf {}
 unsafe impl Sync for Hvf {}
+
+/// Represents an error when [`Hvf`] fails to initialize.
+#[derive(Debug, Error)]
+pub enum HvfError {
+    #[error("couldn't create a RAM")]
+    CreateRamFailed(#[source] std::io::Error),
+
+    #[error("couldn't create a VM ({0:#x})")]
+    CreateVmFailed(NonZero<hv_return_t>),
+
+    #[error("couldn't read ID_AA64MMFR0_EL1 ({0:#x})")]
+    ReadMmfr0Failed(NonZero<hv_return_t>),
+
+    #[error("couldn't read ID_AA64MMFR1_EL1 ({0:#x})")]
+    ReadMmfr1Failed(NonZero<hv_return_t>),
+
+    #[error("couldn't read ID_AA64MMFR2_EL1 ({0:#x})")]
+    ReadMmfr2Failed(NonZero<hv_return_t>),
+}
 
 /// Implementation of [`Hypervisor::CpuErr`].
 #[derive(Debug, Error)]

--- a/gui/src/vmm/hv/macos/mod.rs
+++ b/gui/src/vmm/hv/macos/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use self::cpu::HvfCpu;
-use super::{CpuFeats, Hypervisor};
-use crate::vmm::ram::Ram;
+use super::{CpuFeats, Hypervisor, Ram};
 use crate::vmm::VmmError;
 use applevisor_sys::hv_feature_reg_t::{
     HV_FEATURE_REG_ID_AA64MMFR0_EL1, HV_FEATURE_REG_ID_AA64MMFR1_EL1,

--- a/gui/src/vmm/hv/mod.rs
+++ b/gui/src/vmm/hv/mod.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use super::ram::Ram;
-use std::error::Error;
-
 pub use self::arch::*;
 pub use self::os::new;
+pub use self::ram::*;
+
 use gdbstub::stub::MultiThreadStopReason;
+use std::error::Error;
 
 #[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
 #[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
@@ -13,6 +13,7 @@ mod arch;
 #[cfg_attr(target_os = "macos", path = "macos/mod.rs")]
 #[cfg_attr(target_os = "windows", path = "windows/mod.rs")]
 mod os;
+mod ram;
 
 #[cfg(target_os = "linux")]
 pub type Default = self::os::Kvm;

--- a/gui/src/vmm/hv/mod.rs
+++ b/gui/src/vmm/hv/mod.rs
@@ -26,14 +26,15 @@ pub type Default = self::os::Whp;
 
 /// Underlying hypervisor (e.g. KVM on Linux).
 pub trait Hypervisor: Send + Sync + 'static {
+    type Mapper: RamMapper;
     type Cpu<'a>: CpuRun
     where
         Self: 'a;
     type CpuErr: Error + Send + 'static;
 
     fn cpu_features(&self) -> &CpuFeats;
-    fn ram(&self) -> &Ram;
-    fn ram_mut(&mut self) -> &mut Ram;
+    fn ram(&self) -> &Ram<Self::Mapper>;
+    fn ram_mut(&mut self) -> &mut Ram<Self::Mapper>;
 
     /// This method must be called by a thread that is going to drive the returned CPU.
     fn create_cpu(&self, id: usize) -> Result<Self::Cpu<'_>, Self::CpuErr>;

--- a/gui/src/vmm/hv/ram.rs
+++ b/gui/src/vmm/hv/ram.rs
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pub use self::builder::*;
-
 use std::collections::BTreeSet;
 use std::io::Error;
 use std::num::NonZero;
 use std::sync::{Mutex, MutexGuard};
 use thiserror::Error;
-
-mod builder;
 
 /// Represents main memory of the PS4.
 ///
@@ -83,6 +79,10 @@ impl Ram {
 
     pub fn len(&self) -> NonZero<usize> {
         self.len
+    }
+
+    pub fn block_size(&self) -> NonZero<usize> {
+        self.block_size
     }
 
     /// # Panics

--- a/gui/src/vmm/hv/ram.rs
+++ b/gui/src/vmm/hv/ram.rs
@@ -11,22 +11,20 @@ use thiserror::Error;
 /// until there is an allocation request.
 ///
 /// RAM always started at address 0.
-pub struct Ram {
+pub struct Ram<M: RamMapper> {
     mem: *mut u8,
     len: NonZero<usize>,
     block_size: NonZero<usize>,
     allocated: Mutex<BTreeSet<usize>>,
+    mapper: M,
 }
 
-impl Ram {
-    /// Panics
-    /// If `len` is not multiply by `block_size`.
-    ///
-    /// # Safety
-    /// `block_size` must be greater or equal host page size.
-    pub unsafe fn new(len: NonZero<usize>, block_size: NonZero<usize>) -> Result<Self, Error> {
-        use std::io::Error;
-
+impl<M: RamMapper> Ram<M> {
+    pub(super) unsafe fn new(
+        len: NonZero<usize>,
+        block_size: NonZero<usize>,
+        mapper: M,
+    ) -> Result<Self, Error> {
         assert_eq!(len.get() % block_size, 0);
 
         // Reserve memory range.
@@ -70,6 +68,7 @@ impl Ram {
             len,
             block_size,
             allocated: Mutex::default(),
+            mapper,
         })
     }
 
@@ -109,6 +108,10 @@ impl Ram {
         let start = unsafe { self.mem.add(addr) };
         let mem = unsafe { Self::commit(start, len.get()).map_err(RamError::HostFailed)? };
 
+        self.mapper
+            .map(start, addr, len)
+            .map_err(|e| RamError::MapFailed(Box::new(e)))?;
+
         // Add range to allocated list.
         for addr in (addr..end).step_by(self.block_size.get()) {
             assert!(allocated.insert(addr));
@@ -126,7 +129,7 @@ impl Ram {
         assert_eq!(addr % self.block_size, 0);
         assert_eq!(len.get() % self.block_size, 0);
 
-        // Check if the requested range valid.
+        // Check if the requested range valid so we don't end up unmap non-VM memory.
         let end = addr.checked_add(len.get()).ok_or(RamError::InvalidAddr)?;
 
         if end > self.len.get() {
@@ -137,6 +140,7 @@ impl Ram {
         // be no-op anyway.
         let mut allocated = self.allocated.lock().unwrap();
 
+        // TODO: Unmap this portion from the VM if the OS does not do for us.
         Self::decommit(self.mem.add(addr), len.get()).map_err(RamError::HostFailed)?;
 
         for addr in (addr..end).step_by(self.block_size.get()) {
@@ -233,11 +237,12 @@ impl Ram {
     }
 }
 
-impl Drop for Ram {
+impl<M: RamMapper> Drop for Ram<M> {
     #[cfg(unix)]
     fn drop(&mut self) {
         use libc::munmap;
 
+        // TODO: Unmap this portion from the VM if the OS does not do for us.
         if unsafe { munmap(self.mem.cast(), self.len.get()) } < 0 {
             panic!(
                 "failed to unmap RAM at {:p}: {}",
@@ -251,6 +256,7 @@ impl Drop for Ram {
     fn drop(&mut self) {
         use windows_sys::Win32::System::Memory::{VirtualFree, MEM_RELEASE};
 
+        // TODO: Unmap this portion from the VM if the OS does not do for us.
         if unsafe { VirtualFree(self.mem.cast(), 0, MEM_RELEASE) } == 0 {
             panic!(
                 "failed to free RAM at {:p}: {}",
@@ -261,8 +267,15 @@ impl Drop for Ram {
     }
 }
 
-unsafe impl Send for Ram {}
-unsafe impl Sync for Ram {}
+unsafe impl<M: RamMapper> Send for Ram<M> {}
+unsafe impl<M: RamMapper> Sync for Ram<M> {}
+
+/// Provides methods to map a portion of RAM dynamically.
+pub trait RamMapper: Send + Sync {
+    type Err: std::error::Error + 'static;
+
+    fn map(&self, host: *mut u8, vm: usize, len: NonZero<usize>) -> Result<(), Self::Err>;
+}
 
 /// RAII struct to prevent a range of memory from deallocated.
 pub struct LockedAddr<'a> {
@@ -297,4 +310,7 @@ pub enum RamError {
 
     #[error("host failed")]
     HostFailed(#[source] std::io::Error),
+
+    #[error("couldn't map the memory to the VM")]
+    MapFailed(#[source] Box<dyn std::error::Error>),
 }

--- a/gui/src/vmm/hv/windows/mapper.rs
+++ b/gui/src/vmm/hv/windows/mapper.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::vmm::hv::RamMapper;
+use std::num::NonZero;
+use thiserror::Error;
+
+/// Implementation of [`RamMapper`] for Windows Hypervisor Platform.
+pub struct WhpMapper;
+
+impl RamMapper for WhpMapper {
+    type Err = WhpMapperError;
+
+    fn map(&self, _: *mut u8, _: usize, _: NonZero<usize>) -> Result<(), Self::Err> {
+        Ok(())
+    }
+}
+
+/// Implementation of [`RamMapper::Err`] for Windows Hypervisor Platform.
+#[derive(Debug, Error)]
+pub enum WhpMapperError {}

--- a/gui/src/vmm/hv/windows/mod.rs
+++ b/gui/src/vmm/hv/windows/mod.rs
@@ -17,7 +17,7 @@ mod partition;
 ///
 /// # Safety
 /// `ram_block` must be greater or equal host page size.
-pub fn new(
+pub unsafe fn new(
     cpu: usize,
     ram_size: NonZero<usize>,
     ram_block: NonZero<usize>,

--- a/gui/src/vmm/hv/windows/mod.rs
+++ b/gui/src/vmm/hv/windows/mod.rs
@@ -1,22 +1,37 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use self::cpu::WhpCpu;
+use self::mapper::WhpMapper;
 use self::partition::Partition;
 use super::{CpuFeats, Hypervisor, Ram};
-use crate::vmm::VmmError;
+use std::num::NonZero;
 use std::sync::Arc;
 use thiserror::Error;
 use windows_sys::core::HRESULT;
 
 mod cpu;
+mod mapper;
 mod partition;
 
-pub fn new(cpu: usize, ram: Ram, debug: bool) -> Result<Whp, VmmError> {
+/// Panics
+/// If `ram_size` is not multiply by `ram_block`.
+///
+/// # Safety
+/// `ram_block` must be greater or equal host page size.
+pub fn new(
+    cpu: usize,
+    ram_size: NonZero<usize>,
+    ram_block: NonZero<usize>,
+    debug: bool,
+) -> Result<Whp, WhpError> {
+    // Create RAM.
+    let ram = Ram::new(ram_size, ram_block, WhpMapper).map_err(WhpError::CreateRamFailed)?;
+
     // Setup a partition.
-    let mut part = Partition::new().map_err(VmmError::CreatePartitionFailed)?;
+    let mut part = Partition::new().map_err(WhpError::CreatePartitionFailed)?;
 
     part.set_processor_count(cpu)
-        .map_err(VmmError::SetCpuCountFailed)?;
-    part.setup().map_err(VmmError::SetupPartitionFailed)?;
+        .map_err(WhpError::SetCpuCountFailed)?;
+    part.setup().map_err(WhpError::SetupPartitionFailed)?;
 
     // Map memory.
     part.map_gpa(
@@ -24,7 +39,7 @@ pub fn new(cpu: usize, ram: Ram, debug: bool) -> Result<Whp, VmmError> {
         0,
         ram.len().get().try_into().unwrap(),
     )
-    .map_err(VmmError::MapRamFailed)?;
+    .map_err(WhpError::MapRamFailed)?;
 
     Ok(Whp {
         part,
@@ -39,10 +54,11 @@ pub fn new(cpu: usize, ram: Ram, debug: bool) -> Result<Whp, VmmError> {
 pub struct Whp {
     part: Partition,
     feats: CpuFeats,
-    ram: Ram,
+    ram: Ram<WhpMapper>,
 }
 
 impl Hypervisor for Whp {
+    type Mapper = WhpMapper;
     type Cpu<'a> = WhpCpu<'a>;
     type CpuErr = WhpCpuError;
 
@@ -50,11 +66,11 @@ impl Hypervisor for Whp {
         &self.feats
     }
 
-    fn ram(&self) -> &Ram {
+    fn ram(&self) -> &Ram<Self::Mapper> {
         &self.ram
     }
 
-    fn ram_mut(&mut self) -> &mut Ram {
+    fn ram_mut(&mut self) -> &mut Ram<Self::Mapper> {
         &mut self.ram
     }
 
@@ -65,6 +81,25 @@ impl Hypervisor for Whp {
             .create_virtual_processor(id)
             .map_err(WhpCpuError::CreateVirtualProcessorFailed)
     }
+}
+
+/// Represents an error when [`Whp`] fails to initialize.
+#[derive(Debug, Error)]
+pub enum WhpError {
+    #[error("couldn't create a RAM")]
+    CreateRamFailed(#[source] std::io::Error),
+
+    #[error("couldn't create WHP partition object ({0:#x})")]
+    CreatePartitionFailed(HRESULT),
+
+    #[error("couldn't set number of CPU ({0:#x})")]
+    SetCpuCountFailed(HRESULT),
+
+    #[error("couldn't setup WHP partition ({0:#x})")]
+    SetupPartitionFailed(HRESULT),
+
+    #[error("couldn't map the RAM to WHP partition ({0:#x})")]
+    MapRamFailed(HRESULT),
 }
 
 /// Implementation of [`Hypervisor::CpuErr`].

--- a/gui/src/vmm/hv/windows/mod.rs
+++ b/gui/src/vmm/hv/windows/mod.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use self::cpu::WhpCpu;
 use self::partition::Partition;
-use super::{CpuFeats, Hypervisor};
-use crate::vmm::ram::Ram;
+use super::{CpuFeats, Hypervisor, Ram};
 use crate::vmm::VmmError;
 use std::sync::Arc;
 use thiserror::Error;

--- a/gui/src/vmm/hw/mod.rs
+++ b/gui/src/vmm/hw/mod.rs
@@ -2,8 +2,7 @@
 pub use self::console::*;
 pub use self::vmm::*;
 
-use super::hv::{Cpu, CpuExit, CpuIo, Hypervisor, IoBuf};
-use super::ram::LockedAddr;
+use super::hv::{Cpu, CpuExit, CpuIo, Hypervisor, IoBuf, LockedAddr};
 use super::VmmEventHandler;
 use std::collections::BTreeMap;
 use std::error::Error;

--- a/gui/src/vmm/mod.rs
+++ b/gui/src/vmm/mod.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use self::cpu::CpuManager;
-use self::hv::Hypervisor;
+use self::hv::{Hypervisor, Ram};
 use self::hw::{setup_devices, Device};
 use self::kernel::{
     Kernel, PT_DYNAMIC, PT_GNU_EH_FRAME, PT_GNU_RELRO, PT_GNU_STACK, PT_LOAD, PT_NOTE, PT_PHDR,
 };
-use self::ram::{Ram, RamBuilder};
+use self::ram::RamBuilder;
 use crate::debug::DebugClient;
 use crate::error::RustError;
 use crate::profile::Profile;

--- a/gui/src/vmm/mod.rs
+++ b/gui/src/vmm/mod.rs
@@ -328,21 +328,13 @@ pub unsafe extern "C" fn vmm_start(
         },
     };
 
-    // Setup RAM.
-    let ram = match Ram::new(NonZero::new(1024 * 1024 * 1024 * 8).unwrap(), block_size) {
-        Ok(v) => v,
-        Err(e) => {
-            *err = RustError::with_source("couldn't create a RAM", e).into_c();
-            return null_mut();
-        }
-    };
-
     // Setup virtual devices.
+    let ram = NonZero::new(1024 * 1024 * 1024 * 8).unwrap();
     let event = VmmEventHandler { fp: event, cx };
-    let devices = Arc::new(setup_devices(ram.len().get(), block_size, event));
+    let devices = Arc::new(setup_devices(ram.get(), block_size, event));
 
     // Setup hypervisor.
-    let mut hv = match self::hv::new(8, ram, debugger.is_some()) {
+    let mut hv = match self::hv::new(8, ram, block_size, debugger.is_some()) {
         Ok(v) => v,
         Err(e) => {
             *err = RustError::with_source("couldn't setup a hypervisor", e).into_c();
@@ -690,46 +682,6 @@ pub enum DebugResult {
     Ok,
     Disconnected,
     Error { reason: *mut RustError },
-}
-
-/// Represents an error when [`vmm_new()`] fails.
-#[derive(Debug, Error)]
-enum VmmError {
-    #[cfg(target_os = "windows")]
-    #[error("couldn't create WHP partition object ({0:#x})")]
-    CreatePartitionFailed(windows_sys::core::HRESULT),
-
-    #[cfg(target_os = "windows")]
-    #[error("couldn't set number of CPU ({0:#x})")]
-    SetCpuCountFailed(windows_sys::core::HRESULT),
-
-    #[cfg(target_os = "windows")]
-    #[error("couldn't setup WHP partition ({0:#x})")]
-    SetupPartitionFailed(windows_sys::core::HRESULT),
-
-    #[cfg(target_os = "windows")]
-    #[error("couldn't map the RAM to WHP partition ({0:#x})")]
-    MapRamFailed(windows_sys::core::HRESULT),
-
-    #[cfg(target_os = "macos")]
-    #[error("couldn't create a VM ({0:#x})")]
-    CreateVmFailed(NonZero<applevisor_sys::hv_return_t>),
-
-    #[cfg(target_os = "macos")]
-    #[error("couldn't read ID_AA64MMFR0_EL1 ({0:#x})")]
-    ReadMmfr0Failed(NonZero<applevisor_sys::hv_return_t>),
-
-    #[cfg(target_os = "macos")]
-    #[error("couldn't read ID_AA64MMFR1_EL1 ({0:#x})")]
-    ReadMmfr1Failed(NonZero<applevisor_sys::hv_return_t>),
-
-    #[cfg(target_os = "macos")]
-    #[error("couldn't read ID_AA64MMFR2_EL1 ({0:#x})")]
-    ReadMmfr2Failed(NonZero<applevisor_sys::hv_return_t>),
-
-    #[cfg(target_os = "macos")]
-    #[error("couldn't map memory to the VM ({0:#x})")]
-    MapRamFailed(NonZero<applevisor_sys::hv_return_t>),
 }
 
 /// Represents an error when [`main_cpu()`] fails to reach event loop.

--- a/gui/src/vmm/ram.rs
+++ b/gui/src/vmm/ram.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use super::hv::RamError;
+use super::hv::{RamError, RamMapper};
 use super::Ram;
 use crate::vmm::hv::CpuFeats;
 use crate::vmm::hw::DeviceTree;
@@ -10,16 +10,16 @@ use std::ops::Range;
 use thiserror::Error;
 
 /// Struct to build [`Ram`].
-pub struct RamBuilder<'a> {
-    ram: &'a mut Ram,
+pub struct RamBuilder<'a, M: RamMapper> {
+    ram: &'a mut Ram<M>,
     next: usize,
     kern: Option<Range<usize>>,
     stack: Option<Range<usize>>,
     args: Option<KernelArgs>,
 }
 
-impl<'a> RamBuilder<'a> {
-    pub fn new(ram: &'a mut Ram) -> Self {
+impl<'a, M: RamMapper> RamBuilder<'a, M> {
+    pub fn new(ram: &'a mut Ram<M>) -> Self {
         Self {
             ram,
             next: 0,
@@ -178,7 +178,7 @@ impl<'a> RamBuilder<'a> {
 }
 
 #[cfg(target_arch = "x86_64")]
-impl<'a> RamBuilder<'a> {
+impl<'a, M: RamMapper> RamBuilder<'a, M> {
     pub fn build(
         mut self,
         _: &CpuFeats,
@@ -360,7 +360,7 @@ impl<'a> RamBuilder<'a> {
 }
 
 #[cfg(target_arch = "aarch64")]
-impl<'a> RamBuilder<'a> {
+impl<'a, M: RamMapper> RamBuilder<'a, M> {
     const MA_DEV_NG_NR_NE: u8 = 0; // MEMORY_ATTRS[0]
     const MA_NOR: u8 = 1; // MEMORY_ATTRS[1]
     const MEMORY_ATTRS: [u8; 8] = [0, 0b11111111, 0, 0, 0, 0, 0, 0];

--- a/gui/src/vmm/ram.rs
+++ b/gui/src/vmm/ram.rs
@@ -269,6 +269,8 @@ impl<'a, M: RamMapper> RamBuilder<'a, M> {
         paddr: usize,
         len: usize,
     ) -> Result<(), RamBuilderError> {
+        let ram = self.ram.host_addr().cast_mut(); // TODO: Make this safer.
+
         assert_eq!(len % 4096, 0);
 
         fn set_page_entry(entry: &mut usize, addr: usize) {
@@ -294,7 +296,7 @@ impl<'a, M: RamMapper> RamBuilder<'a, M> {
 
                     unsafe { &mut *pdpt }
                 }
-                v => unsafe { &mut *self.ram.mem.add(v & 0xFFFFFFFFFF000).cast() },
+                v => unsafe { &mut *ram.add(v & 0xFFFFFFFFFF000).cast() },
             };
 
             // Get page-directory table.
@@ -309,7 +311,7 @@ impl<'a, M: RamMapper> RamBuilder<'a, M> {
 
                     unsafe { &mut *pdt }
                 }
-                v => unsafe { &mut *self.ram.mem.add(v & 0xFFFFFFFFFF000).cast() },
+                v => unsafe { &mut *ram.add(v & 0xFFFFFFFFFF000).cast() },
             };
 
             // Get page table.
@@ -324,7 +326,7 @@ impl<'a, M: RamMapper> RamBuilder<'a, M> {
 
                     unsafe { &mut *pt }
                 }
-                v => unsafe { &mut *self.ram.mem.add(v & 0xFFFFFFFFFF000).cast() },
+                v => unsafe { &mut *ram.add(v & 0xFFFFFFFFFF000).cast() },
             };
 
             // Set page table entry.
@@ -343,7 +345,7 @@ impl<'a, M: RamMapper> RamBuilder<'a, M> {
         // Get address and length.
         let addr = self.next;
         let len = (512usize * 8)
-            .checked_next_multiple_of(self.ram.block_size.get())
+            .checked_next_multiple_of(self.ram.block_size().get())
             .and_then(NonZero::new)
             .unwrap();
 

--- a/gui/src/vmm/ram.rs
+++ b/gui/src/vmm/ram.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use super::{Ram, RamError};
+use super::hv::RamError;
+use super::Ram;
 use crate::vmm::hv::CpuFeats;
 use crate::vmm::hw::DeviceTree;
 use crate::vmm::kernel::ProgramHeader;
@@ -63,14 +64,14 @@ impl<'a> RamBuilder<'a> {
     /// If called a second time.
     pub fn alloc_args(&mut self, env: BootEnv, conf: Config) -> Result<(), RamError> {
         assert!(self.args.is_none());
-        assert!(align_of::<BootEnv>() <= self.ram.block_size.get());
+        assert!(align_of::<BootEnv>() <= self.ram.block_size().get());
 
         // Allocate RAM for all arguments.
         let addr = self.next;
         let len = size_of::<BootEnv>()
             .checked_next_multiple_of(align_of::<Config>())
             .and_then(|off| off.checked_add(size_of::<Config>()))
-            .and_then(|len| len.checked_next_multiple_of(self.ram.block_size.get()))
+            .and_then(|len| len.checked_next_multiple_of(self.ram.block_size().get()))
             .and_then(NonZero::new)
             .unwrap();
 
@@ -111,7 +112,11 @@ impl<'a> RamBuilder<'a> {
 
         // Get PT_DYNAMIC.
         let paddr = map.kern_paddr;
-        let kern = unsafe { std::slice::from_raw_parts_mut(self.ram.mem.add(paddr), map.kern_len) };
+        let mut kern = self
+            .ram
+            .lock(paddr, map.kern_len.try_into().unwrap())
+            .unwrap();
+        let kern = unsafe { std::slice::from_raw_parts_mut(kern.as_mut_ptr(), kern.len().get()) };
         let dynamic = p_vaddr
             .checked_add(p_memsz)
             .and_then(|end| kern.get(p_vaddr..end))
@@ -389,7 +394,7 @@ impl<'a> RamBuilder<'a> {
     ) -> Result<RamMap, RamBuilderError> {
         // Allocate page table level 0.
         let page_table = self.next;
-        let len = self.ram.block_size;
+        let len = self.ram.block_size();
         let l0t: &mut [usize; 32] = match self.ram.alloc(page_table, len) {
             Ok(v) => unsafe { &mut *v.as_mut_ptr().cast() },
             Err(e) => return Err(RamBuilderError::AllocPageTableLevel0Failed(e)),
@@ -473,6 +478,7 @@ impl<'a> RamBuilder<'a> {
         attr: u8,
     ) -> Result<(), RamBuilderError> {
         let attr: usize = attr.into();
+        let ram = self.ram.host_addr().cast_mut(); // TODO: Make this safer.
 
         assert_eq!(len % 0x4000, 0);
         assert_eq!(attr & 0b11111000, 0);
@@ -499,7 +505,7 @@ impl<'a> RamBuilder<'a> {
 
                     unsafe { &mut *l1t }
                 }
-                v => unsafe { &mut *self.ram.mem.add(v & 0xFFFFFFFFC000).cast() },
+                v => unsafe { &mut *ram.add(v & 0xFFFFFFFFC000).cast() },
             };
 
             // Get level 2 table.
@@ -514,7 +520,7 @@ impl<'a> RamBuilder<'a> {
 
                     unsafe { &mut *l2t }
                 }
-                v => unsafe { &mut *self.ram.mem.add(v & 0xFFFFFFFFC000).cast() },
+                v => unsafe { &mut *ram.add(v & 0xFFFFFFFFC000).cast() },
             };
 
             // Get level 3 table.
@@ -529,7 +535,7 @@ impl<'a> RamBuilder<'a> {
 
                     unsafe { &mut *l3t }
                 }
-                v => unsafe { &mut *self.ram.mem.add(v & 0xFFFFFFFFC000).cast() },
+                v => unsafe { &mut *ram.add(v & 0xFFFFFFFFC000).cast() },
             };
 
             // Set page descriptor.
@@ -556,7 +562,7 @@ impl<'a> RamBuilder<'a> {
         // Get address and length.
         let addr = self.next;
         let len = (2048usize * 8)
-            .checked_next_multiple_of(self.ram.block_size.get())
+            .checked_next_multiple_of(self.ram.block_size().get())
             .and_then(NonZero::new)
             .unwrap();
 


### PR DESCRIPTION
Found out the Hypervisor Framework do not map memory with `PROT_NONE` into the VM.

The recommended way to review this PR is to review each commit separately.

Closes #991.