### PR TITLE
Removes unnecessary caches

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Generate cache keys
       run: |
         echo "flatpak-runtime=${{ runner.os }}-flatpak-runtime-${{ hashFiles('flatpak.yml') }}" >> $GITHUB_OUTPUT
-        echo "flatpak-build=${{ runner.os }}-flatpak-build-${{ hashFiles('flatpak.yml') }}" >> $GITHUB_OUTPUT
       id: cache-keys
     - name: Restore Flatpak runtimes
       uses: actions/cache/restore@v4
@@ -41,11 +40,6 @@ jobs:
           org.kde.Platform//6.7 org.kde.Sdk//6.7 \
           org.freedesktop.Sdk.Extension.rust-stable//23.08
       if: ${{ steps.flatpak-runtime.outputs.cache-hit != 'true' }}
-    - name: Restore build files
-      uses: actions/cache/restore@v4
-      with:
-        path: .flatpak-builder
-        key: ${{ steps.cache-keys.outputs.flatpak-build }}
     - name: Generate Flatpak branch
       run: |
         my $name;
@@ -68,12 +62,6 @@ jobs:
       run: flatpak build-export flatpak build
     - name: Bundle Flatpak
       run: flatpak build-bundle flatpak obliteration.flatpak io.github.obhq.Obliteration --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Cache build files
-      uses: actions/cache/save@v4
-      with:
-        path: .flatpak-builder
-        key: ${{ steps.cache-keys.outputs.flatpak-build }}-${{ github.run_id }}
-      if: startsWith(github.ref, 'refs/heads/')
     - name: Cache Flatpak runtimes
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -38,16 +38,10 @@ jobs:
         }
 
         open(my $output, '>>', $ENV{GITHUB_OUTPUT}) || die "Cannot open GITHUB_OUTPUT: $!";
-        print $output "cargo=${{ runner.os }}-${{ runner.arch }}-cargo\n";
         print $output "qt=${{ runner.os }}-${{ runner.arch }}-qt-".$qt->hexdigest."\n";
         print $output "target=${{ runner.os }}-${{ runner.arch }}-target\n";
       shell: perl {0}
       id: cache-keys
-    - name: Restore Cargo home
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.cargo
-        key: ${{ steps.cache-keys.outputs.cargo }}
     - name: Restore Qt
       uses: actions/cache/restore@v4
       with:
@@ -116,12 +110,6 @@ jobs:
       with:
         path: target
         key: ${{ steps.cache-keys.outputs.target }}-${{ github.run_id }}
-      if: startsWith(github.ref, 'refs/heads/')
-    - name: Cache Cargo home
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.cargo
-        key: ${{ steps.cache-keys.outputs.cargo }}-${{ github.run_id }}
       if: startsWith(github.ref, 'refs/heads/')
     - name: Cache Qt
       uses: actions/cache/save@v4

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -14,7 +14,6 @@ jobs:
       run: choco install ninja
     - name: Generate cache keys
       run: |
-        echo "cargo=${{ runner.os }}-cargo" >> $env:GITHUB_OUTPUT
         echo "qt=${{ runner.os }}-qt-6.7.2" >> $env:GITHUB_OUTPUT
         echo "target=${{ runner.os }}-target" >> $env:GITHUB_OUTPUT
         echo "vulkan=${{ runner.os }}-vulkan-1.3.290.0" >> $env:GITHUB_OUTPUT
@@ -58,11 +57,6 @@ jobs:
       if: ${{ steps.restore-qt.outputs.cache-hit != 'true' }}
     - name: Set Qt path
       run: echo "CMAKE_PREFIX_PATH=qt" >> $env:GITHUB_ENV
-    - name: Restore Cargo home
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.cargo
-        key: ${{ steps.cache-keys.outputs.cargo }}
     - name: Restore target directory
       uses: actions/cache/restore@v4
       with:
@@ -100,12 +94,6 @@ jobs:
         path: C:\VulkanSDK
         key: ${{ steps.cache-keys.outputs.vulkan }}
       if: startsWith(github.ref, 'refs/heads/') && steps.install-vulkan.outputs.new-install == 'true'
-    - name: Cache Cargo home
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.cargo
-        key: ${{ steps.cache-keys.outputs.cargo }}-${{ github.run_id }}
-      if: startsWith(github.ref, 'refs/heads/')
     - name: Cache Qt
       uses: actions/cache/save@v4
       with:


### PR DESCRIPTION
`.flatpak-builder` is very small so caching does not make sense. For Cargo home it is almost 1 GB, which seems too big. I believe it is because its contains every crates that we have used since we keep caching it. So I thing it should be better not to cache this. The Windows CI also spend a lot of time to restore this so remove this should reduce make it faster.