### PR TITLE
Uses scoped threads on vCPU

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -2,10 +2,6 @@
 find_package(Qt6 REQUIRED COMPONENTS Svg Widgets)
 find_package(Threads REQUIRED)
 
-if(WIN32 OR (UNIX AND NOT APPLE))
-    find_package(Vulkan REQUIRED)
-endif()
-
 # Setup GUI.
 add_executable(obliteration WIN32 MACOSX_BUNDLE
     main.cpp
@@ -13,22 +9,12 @@ add_executable(obliteration WIN32 MACOSX_BUNDLE
     resources.qrc
     settings.cpp)
 
-if(WIN32)
-    target_sources(obliteration PRIVATE vulkan.cpp)
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    target_sources(obliteration PRIVATE vulkan.cpp)
-endif()
-
 set_target_properties(obliteration PROPERTIES AUTOMOC ON AUTORCC ON)
 
 target_compile_features(obliteration PRIVATE cxx_std_17)
 
 target_link_libraries(obliteration PRIVATE Qt6::Svg Qt6::Widgets)
 target_link_libraries(obliteration PRIVATE Threads::Threads)
-
-if(WIN32 OR (UNIX AND NOT APPLE))
-    target_link_libraries(obliteration PRIVATE Vulkan::Vulkan)
-endif()
 
 if(WIN32)
     target_link_libraries(obliteration PRIVATE bcrypt imm32 ntdll setupapi userenv version winhvplatform winmm ws2_32)

--- a/gui/src/vmm/cpu/aarch64.rs
+++ b/gui/src/vmm/cpu/aarch64.rs
@@ -13,7 +13,7 @@ pub type GdbRegs = gdbstub_arch::aarch64::reg::AArch64CoreRegs;
 
 pub(super) const BREAKPOINT_SIZE: NonZero<usize> = unsafe { NonZero::new_unchecked(4) };
 
-impl<H: Hypervisor, E: VmmHandler> gdbstub::target::Target for CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> gdbstub::target::Target for CpuManager<'a, 'b, H, E> {
     type Arch = gdbstub_arch::aarch64::AArch64;
     type Error = GdbError;
 
@@ -26,13 +26,13 @@ impl<H: Hypervisor, E: VmmHandler> gdbstub::target::Target for CpuManager<H, E> 
     }
 }
 
-impl<H: Hypervisor, E: VmmHandler> Breakpoints for CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> Breakpoints for CpuManager<'a, 'b, H, E> {
     fn support_sw_breakpoint(&mut self) -> Option<SwBreakpointOps<'_, Self>> {
         Some(self)
     }
 }
 
-impl<H: Hypervisor, E: VmmHandler> SwBreakpoint for CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> SwBreakpoint for CpuManager<'a, 'b, H, E> {
     fn add_sw_breakpoint(&mut self, addr: u64, kind: usize) -> TargetResult<bool, Self> {
         todo!()
     }

--- a/gui/src/vmm/cpu/controller.rs
+++ b/gui/src/vmm/cpu/controller.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use super::debug::Debuggee;
 use std::mem::ManuallyDrop;
-use std::thread::JoinHandle;
+use std::thread::ScopedJoinHandle;
 
 /// Contains objects to control a CPU from outside.
-pub struct CpuController {
-    thread: ManuallyDrop<JoinHandle<()>>,
+pub struct CpuController<'a> {
+    thread: ManuallyDrop<ScopedJoinHandle<'a, ()>>,
     debug: ManuallyDrop<Option<Debuggee>>,
 }
 
-impl CpuController {
-    pub fn new(thread: JoinHandle<()>, debug: Option<Debuggee>) -> Self {
+impl<'a> CpuController<'a> {
+    pub fn new(thread: ScopedJoinHandle<'a, ()>, debug: Option<Debuggee>) -> Self {
         Self {
             thread: ManuallyDrop::new(thread),
             debug: ManuallyDrop::new(debug),
@@ -22,7 +22,7 @@ impl CpuController {
     }
 }
 
-impl Drop for CpuController {
+impl<'a> Drop for CpuController<'a> {
     fn drop(&mut self) {
         // We need to drop the debug channel first so it will unblock the CPU thread if it is
         // waiting for a request.

--- a/gui/src/vmm/cpu/x86_64.rs
+++ b/gui/src/vmm/cpu/x86_64.rs
@@ -15,7 +15,7 @@ pub type GdbRegs = gdbstub_arch::x86::reg::X86_64CoreRegs;
 
 pub(super) const BREAKPOINT_SIZE: NonZero<usize> = unsafe { NonZero::new_unchecked(1) };
 
-impl<H: Hypervisor, E: VmmHandler> gdbstub::target::Target for CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> gdbstub::target::Target for CpuManager<'a, 'b, H, E> {
     type Arch = X86_64_SSE;
     type Error = GdbError;
 
@@ -28,13 +28,13 @@ impl<H: Hypervisor, E: VmmHandler> gdbstub::target::Target for CpuManager<H, E> 
     }
 }
 
-impl<H: Hypervisor, E: VmmHandler> Breakpoints for CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> Breakpoints for CpuManager<'a, 'b, H, E> {
     fn support_sw_breakpoint(&mut self) -> Option<SwBreakpointOps<'_, Self>> {
         Some(self)
     }
 }
 
-impl<H: Hypervisor, E: VmmHandler> SwBreakpoint for CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> SwBreakpoint for CpuManager<'a, 'b, H, E> {
     fn add_sw_breakpoint(&mut self, addr: u64, _kind: usize) -> TargetResult<bool, Self> {
         let Entry::Vacant(entry) = self.sw_breakpoints.entry(addr) else {
             return Ok(false);

--- a/gui/src/vmm/debug/mod.rs
+++ b/gui/src/vmm/debug/mod.rs
@@ -8,22 +8,22 @@ use gdbstub::stub::state_machine::{GdbStubStateMachine, GdbStubStateMachineInner
 use gdbstub::stub::MultiThreadStopReason;
 use thiserror::Error;
 
-impl<H: Hypervisor, E: VmmHandler> CpuManager<H, E> {
+impl<'a, 'b, H: Hypervisor, E: VmmHandler> CpuManager<'a, 'b, H, E> {
     pub(super) fn dispatch_gdb_idle(
         &mut self,
         mut state: GdbStubStateMachineInner<
             'static,
-            Idle<CpuManager<H, E>>,
-            CpuManager<H, E>,
+            Idle<CpuManager<'a, 'b, H, E>>,
+            CpuManager<'a, 'b, H, E>,
             DebugClient,
         >,
     ) -> Result<
         Result<
-            GdbStubStateMachine<'static, CpuManager<H, E>, DebugClient>,
+            GdbStubStateMachine<'static, CpuManager<'a, 'b, H, E>, DebugClient>,
             GdbStubStateMachineInner<
                 'static,
-                Idle<CpuManager<H, E>>,
-                CpuManager<H, E>,
+                Idle<CpuManager<'a, 'b, H, E>>,
+                CpuManager<'a, 'b, H, E>,
                 DebugClient,
             >,
         >,
@@ -43,12 +43,17 @@ impl<H: Hypervisor, E: VmmHandler> CpuManager<H, E> {
 
     pub(super) fn dispatch_gdb_running(
         &mut self,
-        mut state: GdbStubStateMachineInner<'static, Running, CpuManager<H, E>, DebugClient>,
+        mut state: GdbStubStateMachineInner<
+            'static,
+            Running,
+            CpuManager<'a, 'b, H, E>,
+            DebugClient,
+        >,
         stop: Option<MultiThreadStopReason<u64>>,
     ) -> Result<
         Result<
-            GdbStubStateMachine<'static, CpuManager<H, E>, DebugClient>,
-            GdbStubStateMachineInner<'static, Running, CpuManager<H, E>, DebugClient>,
+            GdbStubStateMachine<'static, CpuManager<'a, 'b, H, E>, DebugClient>,
+            GdbStubStateMachineInner<'static, Running, CpuManager<'a, 'b, H, E>, DebugClient>,
         >,
         DispatchGdbRunningError,
     > {

--- a/gui/vulkan.cpp
+++ b/gui/vulkan.cpp
@@ -1,5 +1,0 @@
-#include "vulkan.hpp"
-
-#include <QVulkanFunctions>
-
-QVulkanFunctions *vkFunctions;

--- a/gui/vulkan.hpp
+++ b/gui/vulkan.hpp
@@ -1,5 +1,0 @@
-#pragma once
-
-class QVulkanFunctions;
-
-extern QVulkanFunctions *vkFunctions;


### PR DESCRIPTION
With this we will having too many generic parameters on the VMM but the benefits we get from this is too good since it allows us to borrow any variables we need. Let's hope we can reduce those generic parameters in the future.