### PR TITLE
Renames event handlers on RuntimeWindow

### DIFF
--- a/gui/src/rt/window.rs
+++ b/gui/src/rt/window.rs
@@ -1,13 +1,22 @@
 use std::error::Error;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::event::{DeviceId, InnerSizeWriter};
 
 /// Encapsulates winit window with window-specific logic.
 ///
 /// The event loop will exit immediately if any method return an error.
 pub trait RuntimeWindow {
-    fn update_size(&self, v: PhysicalSize<u32>) -> Result<(), Box<dyn Error + Send + Sync>>;
-    fn set_active(&self, v: bool) -> Result<(), Box<dyn Error + Send + Sync>>;
-    fn update_cursor(&self, v: PhysicalPosition<f64>) -> Result<(), Box<dyn Error + Send + Sync>>;
-    fn update_scale_factor(&self, v: f64) -> Result<(), Box<dyn Error + Send + Sync>>;
-    fn redraw(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
+    fn on_resized(&self, new: PhysicalSize<u32>) -> Result<(), Box<dyn Error + Send + Sync>>;
+    fn on_focused(&self, gained: bool) -> Result<(), Box<dyn Error + Send + Sync>>;
+    fn on_cursor_moved(
+        &self,
+        dev: DeviceId,
+        pos: PhysicalPosition<f64>,
+    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    fn on_scale_factor_changed(
+        &self,
+        new: f64,
+        sw: InnerSizeWriter,
+    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    fn on_redraw_requested(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
 }


### PR DESCRIPTION
I think we should extract `rt` into a dedicated crate in the future and publish it on crates.io so people can use it. So it should be better to make method name the same as winit event so it is easy to understand for other people.