### PR TITLE
Renames graphics types to match its behavior

### DIFF
--- a/gui/src/graphics/metal/engine.rs
+++ b/gui/src/graphics/metal/engine.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::graphics::Screen;
+use crate::graphics::Graphics;
 use metal::{Device, MetalLayer};
 use thiserror::Error;
 
-/// Implementation of [`Screen`] using Metal.
+/// Implementation of [`Graphics`] using Metal.
 ///
 /// Fields in this struct need to be dropped in a correct order.
 pub struct MetalScreen {
@@ -31,7 +31,7 @@ impl MetalScreen {
     }
 }
 
-impl Screen for MetalScreen {}
+impl Graphics for MetalScreen {}
 
 /// Represents an error when [`MetalScreen::new()`] fails.
 #[derive(Debug, Error)]

--- a/gui/src/graphics/metal/mod.rs
+++ b/gui/src/graphics/metal/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use self::screen::MetalScreen;
-use super::Graphics;
+use self::engine::MetalScreen;
+use super::EngineBuilder;
 use crate::profile::Profile;
 use metal::Device;
 use std::ops::Deref;
@@ -8,33 +8,33 @@ use std::sync::Arc;
 use thiserror::Error;
 use winit::window::WindowAttributes;
 
-mod screen;
+mod engine;
 mod window;
 
-pub fn new() -> Result<impl Graphics, GraphicsError> {
-    Ok(Metal {
+pub fn builder() -> Result<impl EngineBuilder, GraphicsError> {
+    Ok(MetalBuilder {
         devices: Device::all(),
     })
 }
 
-/// Implementation of [`Graphics`] using Metal.
-struct Metal {
+/// Implementation of [`EngineBuilder`] for Metal.
+struct MetalBuilder {
     devices: Vec<metal::Device>,
 }
 
-impl Graphics for Metal {
+impl EngineBuilder for MetalBuilder {
     type PhysicalDevice = metal::Device;
-    type Screen = MetalScreen;
+    type Engine = MetalScreen;
 
     fn physical_devices(&self) -> &[Self::PhysicalDevice] {
         &self.devices
     }
 
-    fn create_screen(
+    fn build(
         self,
         profile: &Profile,
-        attrs: WindowAttributes,
-    ) -> Result<Arc<Self::Screen>, GraphicsError> {
+        screen: WindowAttributes,
+    ) -> Result<Arc<Self::Engine>, GraphicsError> {
         todo!()
     }
 }

--- a/gui/src/graphics/mod.rs
+++ b/gui/src/graphics/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pub use self::engine::{new, GraphicsError};
+pub use self::engine::{builder, GraphicsError};
 
 use crate::profile::Profile;
 use std::sync::Arc;
@@ -9,27 +9,27 @@ use winit::window::WindowAttributes;
 #[cfg_attr(not(target_os = "macos"), path = "vulkan/mod.rs")]
 mod engine;
 
-/// The underlying graphics engine (e.g. Vulkan).
-pub trait Graphics: Sized + 'static {
+/// Provides method to build [`Graphics`].
+pub trait EngineBuilder {
     type PhysicalDevice: PhysicalDevice;
-    type Screen: Screen;
+    type Engine: Graphics;
 
     fn physical_devices(&self) -> &[Self::PhysicalDevice];
 
     /// Currently this method was designed to run only once per application lifetime.
-    fn create_screen(
+    fn build(
         self,
         profile: &Profile,
-        attrs: WindowAttributes,
-    ) -> Result<Arc<Self::Screen>, GraphicsError>;
+        screen: WindowAttributes,
+    ) -> Result<Arc<Self::Engine>, GraphicsError>;
 }
 
 pub trait PhysicalDevice: Sized {
     fn name(&self) -> &str;
 }
 
-/// Encapsulates a platform-specific window for drawing a VM screen.
+/// The underlying graphics engine (e.g. Vulkan).
 ///
-/// This trait act as a thin layer for graphics engine for the VMM to use. At compile-time this
+/// This trait act as a thin layer for graphics engine to be used by VMM. At compile-time this
 /// layer will be optimized out and aggressively inlined the same as Hypervisor trait.
-pub trait Screen: Send + Sync + 'static {}
+pub trait Graphics: Send + Sync + 'static {}

--- a/gui/src/graphics/vulkan/window.rs
+++ b/gui/src/graphics/vulkan/window.rs
@@ -1,4 +1,4 @@
-use super::screen::VulkanScreen;
+use super::engine::VulkanScreen;
 use super::GraphicsError;
 use crate::rt::{Hook, RuntimeWindow};
 use ash::vk::SurfaceKHR;
@@ -16,29 +16,29 @@ use winit::window::{Window, WindowId};
 pub struct VulkanWindow {
     surface: SurfaceKHR,
     window: Window,
-    screen: Arc<VulkanScreen>,
+    engine: Arc<VulkanScreen>,
 }
 
 impl VulkanWindow {
     pub fn new(
-        screen: &Arc<VulkanScreen>,
+        engine: &Arc<VulkanScreen>,
         window: Window,
     ) -> Result<Rc<Self>, Box<dyn Error + Send + Sync>> {
         // Create VkSurfaceKHR.
         let surface =
-            unsafe { screen.create_surface(&window) }.map_err(GraphicsError::CreateSurface)?;
+            unsafe { engine.create_surface(&window) }.map_err(GraphicsError::CreateSurface)?;
 
         Ok(Rc::new(Self {
             surface,
             window,
-            screen: screen.clone(),
+            engine: engine.clone(),
         }))
     }
 }
 
 impl Drop for VulkanWindow {
     fn drop(&mut self) {
-        unsafe { self.screen.destroy_surface(self.surface) };
+        unsafe { self.engine.destroy_surface(self.surface) };
     }
 }
 


### PR DESCRIPTION
This does not rename `VulkanScreen` and `MetalScreen` yet to make Git treat those files as a rename so it is easy to review.