### PR TITLE
Fix slint deprecated attributes, adjust language, fix windows launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,10 @@
       },
       "osx": {
         "program": "${workspaceFolder}/dist/Obliteration.app/Contents/MacOS/Obliteration"
-      }
+      },
+      "windows": {
+        "program": "${workspaceFolder}/dist/obliteration.exe"
+      },
     },
     {
       "name": "Kernel",

--- a/gui/src/hv/windows/cpu.rs
+++ b/gui/src/hv/windows/cpu.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use crate::hv::{Cpu, CpuCommit, CpuDebug, CpuExit, CpuIo, CpuRun, CpuStates, IoBuf};
 use gdbstub::stub::MultiThreadStopReason;
-use std::error::Error;
 use std::marker::PhantomData;
 use std::mem::{size_of, zeroed, MaybeUninit};
 use thiserror::Error;

--- a/gui/src/rt/mod.rs
+++ b/gui/src/rt/mod.rs
@@ -29,7 +29,7 @@ mod window;
 ///
 /// Note that our async executor only dispatch a pending future when it is wakeup by
 /// [`std::task::Waker`]. Any pending futures that need to wakeup by an external event like I/O need
-/// a dedicated thread to invoke [`std::task::Waker::wake()`] when the I/O is ready. That mean our
+/// a dedicated thread to invoke [`std::task::Waker::wake()`] when the I/O is ready. That means our
 /// async executor will not work with Tokio by default.
 ///
 /// To create a window, call [`create_window()`] from `main` future.
@@ -88,7 +88,7 @@ pub fn raw_display_handle() -> RawDisplayHandle {
 }
 
 /// You need to call [`register_window()`] after this to receive events for the created window and
-/// you should do it before the first `await` otherwise you may missed some initial events.
+/// you should do it before the first `await` otherwise you may miss some initial events.
 ///
 /// # Panics
 /// If called from the other thread than main thread.
@@ -96,8 +96,8 @@ pub fn create_window(attrs: WindowAttributes) -> Result<Window, OsError> {
     Context::with(move |cx| cx.el.create_window(attrs))
 }
 
-/// Note that the runtime **do not** hold a strong reference to `win` and it will automatically
-/// removed when the underlying winit window destroyed.
+/// Note that the runtime **does not** hold a strong reference to `win` and it will automatically
+/// be removed when the underlying winit window is destroyed.
 ///
 /// # Panics
 /// - If called from the other thread than main thread.
@@ -120,7 +120,7 @@ pub fn register_global(obj: Rc<dyn Any>) {
     Context::with(move |cx| assert!(cx.objects.insert(id, obj).is_none()))
 }
 
-/// Returns object that was registered with [`register()`].
+/// Returns an object that was registered with [`register()`].
 ///
 /// # Panics
 /// If called from the other thread than main thread.

--- a/gui/src/ui/backend/mod.rs
+++ b/gui/src/ui/backend/mod.rs
@@ -6,7 +6,6 @@ use crate::rt::{create_window, raw_display_handle, WindowHandler};
 use i_slint_core::graphics::RequestedGraphicsAPI;
 use i_slint_renderer_skia::SkiaRenderer;
 use rustc_hash::FxHashMap;
-use rwh05::RawDisplayHandle;
 use slint::platform::{
     duration_until_next_timer_update, update_timers_and_animations, SetPlatformError, WindowAdapter,
 };
@@ -41,6 +40,9 @@ impl SlintBackend {
     /// # Safety
     /// The returned [`SlintBackend`] must not outlive the event loop.
     pub unsafe fn new() -> Result<Self, BackendError> {
+        #[cfg(target_os = "linux")]
+        use rwh05::RawDisplayHandle;
+
         let mut b = Self {
             #[cfg(target_os = "linux")]
             wayland: None,

--- a/gui/src/ui/modal.rs
+++ b/gui/src/ui/modal.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 /// Encapsulates a modal window and its parent.
 ///
-/// This struct force the modal window to be dropped before its parent.
+/// This struct forces the modal window to be dropped before its parent.
 pub struct Modal<'a, W, P> {
     window: W,
     parent: &'a P,

--- a/gui/src/ui/windows/mod.rs
+++ b/gui/src/ui/windows/mod.rs
@@ -1,7 +1,5 @@
 use super::{Modal, PlatformExt, PlatformWindow};
-use crate::rt::WindowHandler;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use slint::ComponentHandle;
 use std::io::Error;
 use thiserror::Error;
 use windows_sys::Win32::Foundation::HWND;

--- a/gui/ui/error.slint
+++ b/gui/ui/error.slint
@@ -46,7 +46,7 @@ export component ErrorPopup inherits PopupWindow {
 
     callback close-clicked <=> ab.close;
 
-    close-on-click: false;
+    close-policy: PopupClosePolicy.no-auto-close;
 
     Rectangle {
         border-color: Palette.border;

--- a/gui/ui/setup/firmware.slint
+++ b/gui/ui/setup/firmware.slint
@@ -38,7 +38,7 @@ export component InstallFirmware inherits PopupWindow {
     in property <string> status;
     in property <float> progress;
 
-    close-on-click: false;
+    close-policy: PopupClosePolicy.no-auto-close;
 
     Rectangle {
         background: Palette.alternate-background;

--- a/kernel/src/context/x86_64.rs
+++ b/kernel/src/context/x86_64.rs
@@ -37,7 +37,7 @@ impl Context {
     ///
     /// At a glance this may looks incorrect due to `0xc0000102` is `KERNEL_GS_BAS` according to the
     /// docs. The problem is the CPU always use the value from `0xc0000101` regardless the current
-    /// privilege level. That mean `KERNEL_GS_BAS` is the name when the CPU currently on the user
+    /// privilege level. That means `KERNEL_GS_BAS` is the name when the CPU currently on the user
     /// space.
     ///
     /// This also set user-mode `FS` and `GS` to null.

--- a/kernel/src/subsystem/mod.rs
+++ b/kernel/src/subsystem/mod.rs
@@ -1,5 +1,5 @@
 /// Subsystem of the kernel.
 ///
 /// There should be only one instance for each subsystem. Normally it will live forever until the
-/// machine is shutdown. That mean it is okay to to leak it.
+/// machine is shutdown. That means it is okay to to leak it.
 pub trait Subsystem: Send + Sync + 'static {}

--- a/src/kernel/src/event/mod.rs
+++ b/src/kernel/src/event/mod.rs
@@ -13,8 +13,8 @@ pub struct Event<T: EventType> {
 impl<T: EventType> Event<T> {
     /// See `eventhandler_register` on the PS4 for a reference.
     ///
-    /// `handler` must not call into any function that going to trigger any event in the same
-    /// [`EventSet`] because it can cause a deadlock. That mean what `handler` can do is limited.
+    /// `handler` must not call into any function that is going to trigger any event in the same
+    /// [`EventSet`] because it can cause a deadlock. That means what `handler` can do is limited.
     pub fn subscribe<S: Subsystem>(
         &mut self,
         subsys: &Arc<S>,

--- a/src/kernel/src/fs/dev/mod.rs
+++ b/src/kernel/src/fs/dev/mod.rs
@@ -108,7 +108,7 @@ impl DevFs {
             let dirents = dev.dirents();
 
             if let Some(dirent) = dirents.get(self.index).and_then(|e| e.as_ref()) {
-                // If there is a strong reference that mean it is our dirent.
+                // If there is a strong reference that means it is our dirent.
                 if dirent.strong_count() != 0 {
                     continue;
                 }

--- a/src/kernel/src/fs/host/mod.rs
+++ b/src/kernel/src/fs/host/mod.rs
@@ -63,7 +63,7 @@ pub fn mount(
 /// Implementation of [`Filesystem`] to mount a directory from the host.
 ///
 /// We subtitute `exfatfs` and `pfs` with this because root FS on the PS4 is exFAT and game data is
-/// PFS. That mean we must report this either as `exfatfs` or `pfs` otherwise it might be unexpected
+/// PFS. That measn we must report this either as `exfatfs` or `pfs` otherwise it might be unexpected
 /// by the PS4.
 #[derive(Debug)]
 pub struct HostFs {

--- a/src/kernel/src/fs/path.rs
+++ b/src/kernel/src/fs/path.rs
@@ -80,7 +80,7 @@ impl VPath {
     }
 
     pub fn components(&self) -> Components<'_> {
-        // SAFETY: The path always is an absolute path that mean we have at least / in the
+        // SAFETY: The path always is an absolute path that means we have at least / in the
         // beginning.
         Components(unsafe { self.0.get_unchecked(1..) })
     }

--- a/src/kernel/src/fs/perm.rs
+++ b/src/kernel/src/fs/perm.rs
@@ -113,7 +113,7 @@ pub fn check_access(
 ///
 /// On the PS4 this is `u32`. But some functions in the PS4 use `u16` to represent file mode. The
 /// maximum value for file mode, which is `0777` take only 9 bits. So let's use `u16` and don't make
-/// this struct representation as a transparent. That mean we can't use this type directly on the
+/// this struct representation as a transparent. That means we can't use this type directly on the
 /// function parameter or its return type if that function will be called by the PS4.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Mode(u16);

--- a/src/kernel/src/log/entry.rs
+++ b/src/kernel/src/log/entry.rs
@@ -96,7 +96,7 @@ impl LogEntry {
             None => return,
         };
 
-        // Do not strip "kernel/src/" due to we also set a panic hook. That mean the file path may
+        // Do not strip "kernel/src/" due to us also setting a panic hook. That means the file path may
         // be from another crate.
         write!(stdout, ": {file}").unwrap();
         write!(self.plain, ": {file}").unwrap();

--- a/src/kernel/src/vm/vm.rs
+++ b/src/kernel/src/vm/vm.rs
@@ -468,8 +468,8 @@ impl VmSpace {
 
         // Determine how to allocate.
         let (addr, len, storage) = if self.allocation_granularity < Self::VIRTUAL_PAGE_SIZE {
-            // If allocation granularity is smaller than the virtual page that mean the result of
-            // mmap may not aligned correctly. In this case we need to do 2 allocations. The first
+            // If allocation granularity is smaller than the virtual page that means the result of
+            // mmap may not be aligned correctly. In this case we need to do 2 allocations. The first
             // allocation will be large enough for a second allocation with fixed address.
             // The whole idea is coming from: https://stackoverflow.com/a/31411825/1829232
             let len = len + (Self::VIRTUAL_PAGE_SIZE - self.allocation_granularity);
@@ -481,8 +481,8 @@ impl VmSpace {
 
             (addr, len, storage)
         } else {
-            // If allocation granularity is equal or larger than the virtual page that mean the
-            // result of mmap will always aligned correctly.
+            // If allocation granularity is equal or larger than the virtual page, that means the
+            // result of mmap will always be aligned correctly.
             let storage = Memory::new(addr, len)?;
             let addr = storage.addr();
 

--- a/src/obconf/src/env/vm.rs
+++ b/src/obconf/src/env/vm.rs
@@ -37,8 +37,8 @@ pub enum KernelExit {
 ///
 /// Beware that each write to [`Self::msg_len`] except the last one may not cover the full message.
 /// The consequence of this is [`Self::msg_addr`] may point to an incomplete UTF-8 byte sequence.
-/// That mean you should buffer the message until [`Self::commit`] has been written before validate
-/// if it is a valid UTF-8.
+/// That means you should buffer the message until [`Self::commit`] has been written before validating
+/// if it is valid UTF-8.
 #[cfg(feature = "virt")]
 #[repr(C)]
 pub struct ConsoleMemory {

--- a/src/tls/src/lib.rs
+++ b/src/tls/src/lib.rs
@@ -159,9 +159,9 @@ impl<T> Drop for Tls<T> {
             None => return,
         };
 
-        // Destroy the value for the current thread. When we are here that mean all other threads
-        // that are borrowed us has been terminated, which imply that the values for those thread
-        // has already been destroyed by storage destructor.
+        // Destroy the value for the current thread. When we are here that means all other threads
+        // that have borrowed us have been terminated, which implies that the values for those threads
+        // have already been destroyed by storage destructor.
         #[cfg(unix)]
         unsafe {
             // On Windows the FlsFree() will call the destructor so we don't need to destroy the


### PR DESCRIPTION
I don't know about you, but vscode said something like 'program' is required when trying to launch.

This also fixes some 'unused import' warnings.