### PR TITLE
Uses our Wayland event queue to construct WindowIdentifier

### DIFF
--- a/gui/src/ui/backend/mod.rs
+++ b/gui/src/ui/backend/mod.rs
@@ -195,6 +195,10 @@ pub enum BackendError {
     BindXdgWmDialogV1(#[source] wayland_client::globals::BindError),
 
     #[cfg(target_os = "linux")]
+    #[error("couldn't bind zxdg_exporter_v2")]
+    BindZxdgExporterV2(#[source] wayland_client::globals::BindError),
+
+    #[cfg(target_os = "linux")]
     #[error("couldn't dispatch Wayland request")]
     DispatchWayland(#[source] wayland_client::DispatchError),
 }

--- a/gui/src/ui/macos/dialogs.rs
+++ b/gui/src/ui/macos/dialogs.rs
@@ -1,8 +1,8 @@
+use crate::rt::WinitWindow;
 use crate::ui::FileType;
-use slint::ComponentHandle;
 use std::path::PathBuf;
 
-pub async fn open_file<T: ComponentHandle>(
+pub async fn open_file<T: WinitWindow>(
     parent: &T,
     title: impl AsRef<str>,
     ty: FileType,
@@ -10,6 +10,6 @@ pub async fn open_file<T: ComponentHandle>(
     todo!();
 }
 
-pub async fn open_dir<T: ComponentHandle>(parent: &T, title: impl AsRef<str>) -> Option<PathBuf> {
+pub async fn open_dir<T: WinitWindow>(parent: &T, title: impl AsRef<str>) -> Option<PathBuf> {
     todo!()
 }

--- a/gui/src/ui/windows/dialogs.rs
+++ b/gui/src/ui/windows/dialogs.rs
@@ -1,8 +1,8 @@
+use crate::rt::WinitWindow;
 use crate::ui::FileType;
-use slint::ComponentHandle;
 use std::path::PathBuf;
 
-pub async fn open_file<T: ComponentHandle>(
+pub async fn open_file<T: WinitWindow>(
     parent: &T,
     title: impl AsRef<str>,
     ty: FileType,
@@ -10,6 +10,6 @@ pub async fn open_file<T: ComponentHandle>(
     todo!();
 }
 
-pub async fn open_dir<T: ComponentHandle>(parent: &T, title: impl AsRef<str>) -> Option<PathBuf> {
+pub async fn open_dir<T: WinitWindow>(parent: &T, title: impl AsRef<str>) -> Option<PathBuf> {
     todo!()
 }


### PR DESCRIPTION
`WindowIdentifier::from_raw_handle` on Wayland always create a new set of global objects on the compositor on each invocation, which cause a memory to leak since those objects will be free only when the connection with compositor is closed.