### PR TITLE
Splits context activation into two stages

### DIFF
--- a/kernel/src/context/aarch64.rs
+++ b/kernel/src/context/aarch64.rs
@@ -7,7 +7,7 @@ pub struct ContextArgs {}
 /// Extended [Base] for AArch64.
 #[repr(C)]
 pub(super) struct Context {
-    base: Base, // Must be first field.
+    pub base: Base, // Must be first field.
 }
 
 impl Context {
@@ -19,11 +19,15 @@ impl Context {
         todo!();
     }
 
-    pub unsafe fn load_fixed_ptr<const O: usize, T>() -> *const T {
+    pub unsafe fn load_static_ptr<const O: usize, T>() -> *const T {
         todo!()
     }
 
-    pub unsafe fn load_usize<const O: usize>() -> usize {
+    pub unsafe fn load_ptr<const O: usize, T>() -> *const T {
+        todo!()
+    }
+
+    pub unsafe fn load_volatile_usize<const O: usize>() -> usize {
         todo!()
     }
 }

--- a/kernel/src/context/arc.rs
+++ b/kernel/src/context/arc.rs
@@ -16,8 +16,18 @@ pub struct BorrowedArc<T>(*const T); // A pointer make this type automatically !
 
 impl<T> BorrowedArc<T> {
     /// # Safety
+    /// `v` must be owned by [Arc](alloc::sync::Arc) if not null.
+    pub(super) const unsafe fn new(v: *const T) -> Option<Self> {
+        if v.is_null() {
+            None
+        } else {
+            Some(Self(v))
+        }
+    }
+
+    /// # Safety
     /// `v` must be owned by [Arc](alloc::sync::Arc).
-    pub(super) unsafe fn new(v: *const T) -> Self {
+    pub(super) const unsafe fn from_non_null(v: *const T) -> Self {
         Self(v)
     }
 

--- a/kernel/src/context/local.rs
+++ b/kernel/src/context/local.rs
@@ -14,8 +14,6 @@ use core::ops::Deref;
 pub struct CpuLocal<T>(Vec<T>);
 
 impl<T> CpuLocal<T> {
-    /// # Context safety
-    /// This function does not require a CPU context on **stage 1** heap as long as `f` does not.
     pub fn new(mut f: impl FnMut(usize) -> T) -> Self {
         let len = config().max_cpu.get();
         let mut vec = Vec::with_capacity(len);

--- a/kernel/src/context/x86_64.rs
+++ b/kernel/src/context/x86_64.rs
@@ -19,9 +19,9 @@ pub struct ContextArgs {
 /// Extended [Base] for x86-64.
 #[repr(C)]
 pub(super) struct Context {
-    base: Base,        // Must be first field.
-    trap_rsp: *mut u8, // pc_rsp0
-    user_rsp: usize,   // pc_scratch_rsp
+    pub base: Base,        // Must be first field.
+    pub trap_rsp: *mut u8, // pc_rsp0
+    pub user_rsp: usize,   // pc_scratch_rsp
 }
 
 impl Context {
@@ -50,7 +50,7 @@ impl Context {
         wrmsr(0xc0000102, 0);
     }
 
-    pub unsafe fn load_fixed_ptr<const O: usize, T>() -> *const T {
+    pub unsafe fn load_static_ptr<const O: usize, T>() -> *const T {
         let mut v;
 
         asm!(
@@ -63,7 +63,20 @@ impl Context {
         v
     }
 
-    pub unsafe fn load_usize<const O: usize>() -> usize {
+    pub unsafe fn load_ptr<const O: usize, T>() -> *const T {
+        let mut v;
+
+        asm!(
+            "mov {out}, gs:[{off}]",
+            off = const O,
+            out = out(reg) v,
+            options(pure, readonly, preserves_flags, nostack)
+        );
+
+        v
+    }
+
+    pub unsafe fn load_volatile_usize<const O: usize>() -> usize {
         let mut v;
 
         asm!(

--- a/kernel/src/event/mod.rs
+++ b/kernel/src/event/mod.rs
@@ -19,9 +19,6 @@ impl<S> EventSet<S> {
 }
 
 impl<S: Default> Default for EventSet<S> {
-    /// # Context safety
-    /// This function does not require a CPU context as long as [`Default`] implementation on `S`
-    /// does not.
     fn default() -> Self {
         Self(Mutex::default())
     }
@@ -35,8 +32,6 @@ pub struct Event<T: EventType> {
 }
 
 impl<T: EventType> Default for Event<T> {
-    /// # Context safety
-    /// This function does not require a CPU context.
     fn default() -> Self {
         Self {
             subscribers: BTreeMap::new(),

--- a/kernel/src/lock/mutex/mod.rs
+++ b/kernel/src/lock/mutex/mod.rs
@@ -15,9 +15,6 @@ pub struct Mutex<T> {
 
 impl<T> Mutex<T> {
     /// See `mtx_init` on the PS4 for a reference.
-    ///
-    /// # Context safety
-    /// This function does not require a CPU context.
     pub const fn new(data: T) -> Self {
         Self {
             data: UnsafeCell::new(data),
@@ -83,9 +80,6 @@ impl<T> Mutex<T> {
 }
 
 impl<T: Default> Default for Mutex<T> {
-    /// # Context safety
-    /// This function does not require a CPU context as long as [`Default`] implementation on `T`
-    /// does not.
     fn default() -> Self {
         Self::new(T::default())
     }

--- a/kernel/src/malloc/stage2.rs
+++ b/kernel/src/malloc/stage2.rs
@@ -1,6 +1,6 @@
 use crate::config::PAGE_SIZE;
-use crate::context::{current_thread, CpuLocal};
-use crate::uma::{Uma, UmaFlags, UmaZone};
+use crate::context::{current_thread, current_uma, CpuLocal};
+use crate::uma::{UmaFlags, UmaZone};
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -29,10 +29,11 @@ impl Stage2 {
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x1A4B80|
-    pub fn new(uma: &mut Uma) -> Self {
+    pub fn new() -> Self {
         // The possible of maximum alignment that Layout allowed is a bit before the most
         // significant bit of isize (e.g. 0x4000000000000000 on 64 bit system). So we can use
         // "size_of::<usize>() * 8 - 1" to get the size of array for all possible alignment.
+        let uma = current_uma().unwrap();
         let zones = core::array::from_fn(|align| {
             let mut zones = Vec::with_capacity(Self::KMEM_ZSIZE + 1);
             let mut last = 0;

--- a/kernel/src/proc/mod.rs
+++ b/kernel/src/proc/mod.rs
@@ -25,8 +25,6 @@ pub struct ProcMgr {
 }
 
 impl ProcMgr {
-    /// # Context safety
-    /// This function does not require a CPU context.
     pub fn new() -> Arc<Self> {
         let events = Arc::default();
 

--- a/kernel/src/uma/keg.rs
+++ b/kernel/src/uma/keg.rs
@@ -4,9 +4,6 @@ pub struct UmaKeg {}
 impl UmaKeg {
     /// See `keg_ctor` on the Orbis for a reference.
     ///
-    /// # Context safety
-    /// This function does not require a CPU context on **stage 1** heap.
-    ///
     /// # Reference offsets
     /// | Version | Offset |
     /// |---------|--------|

--- a/kernel/src/uma/mod.rs
+++ b/kernel/src/uma/mod.rs
@@ -1,6 +1,7 @@
 pub use self::zone::*;
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use bitfield_struct::bitfield;
 use core::num::NonZero;
 
@@ -15,28 +16,22 @@ impl Uma {
     /// See `uma_startup` on the Orbis for a reference. Beware that our implementation cannot access
     /// the CPU context due to this function can be called before context activation.
     ///
-    /// # Context safety
-    /// This function does not require a CPU context on **stage 1** heap.
-    ///
     /// # Reference offsets
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x13CA70|
-    pub fn new() -> Self {
-        Self {}
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {})
     }
 
     /// See `uma_zcreate` on the Orbis for a reference.
-    ///
-    /// # Context safety
-    /// This function does not require a CPU context on **stage 1** heap.
     ///
     /// # Reference offsets
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x13DC80|
     pub fn create_zone(
-        &mut self,
+        &self,
         name: impl Into<String>,
         size: NonZero<usize>,
         align: Option<usize>,

--- a/kernel/src/uma/zone.rs
+++ b/kernel/src/uma/zone.rs
@@ -25,9 +25,6 @@ impl UmaZone {
 
     /// See `zone_ctor` on Orbis for a reference.
     ///
-    /// # Context safety
-    /// This function does not require a CPU context on **stage 1** heap.
-    ///
     /// # Reference offsets
     /// | Version | Offset |
     /// |---------|--------|


### PR DESCRIPTION
This will lifting a lot of restrictions while we initialize the kernel since the only places that need to support running without a context is panic handler, console printing and stage 1 heap. The downside is access to all global objects will be guarded by null checking. This should not be a problem as long as we don't do it in a tight loop.