### PR TITLE
Populates boot_address and mptramp_pagetables

### DIFF
--- a/kernel/src/aarch64.rs
+++ b/kernel/src/aarch64.rs
@@ -1,5 +1,10 @@
-use crate::context::ContextArgs;
+use alloc::sync::Arc;
 
-pub unsafe fn setup_main_cpu() -> ContextArgs {
+pub unsafe fn setup_main_cpu() -> Arc<ArchConfig> {
     todo!()
+}
+
+/// Contains architecture-specific configurations obtained from [`setup_main_cpu()`].
+pub struct ArchConfig {
+    pub secondary_start: &'static [u8],
 }

--- a/kernel/src/context/aarch64.rs
+++ b/kernel/src/context/aarch64.rs
@@ -1,10 +1,8 @@
 use super::Base;
+use crate::arch::ArchConfig;
 use crate::proc::Thread;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
-
-/// Contains data passed from CPU setup function for context activation.
-pub struct ContextArgs {}
 
 /// Extended [Base] for AArch64.
 #[repr(C)]
@@ -14,7 +12,7 @@ pub(super) struct Context {
 }
 
 impl Context {
-    pub fn new(base: Base, args: ContextArgs) -> Self {
+    pub fn new(base: Base, arch: &ArchConfig) -> Self {
         Self {
             base,
             phantom: PhantomPinned,

--- a/kernel/src/context/x86_64.rs
+++ b/kernel/src/context/x86_64.rs
@@ -1,5 +1,5 @@
 use super::Base;
-use crate::arch::wrmsr;
+use crate::arch::{ArchConfig, wrmsr};
 use core::arch::asm;
 use core::marker::PhantomPinned;
 use core::mem::offset_of;
@@ -13,11 +13,6 @@ pub const fn current_user_rsp_offset() -> usize {
     offset_of!(Context, user_rsp)
 }
 
-/// Contains data passed from CPU setup function for context activation.
-pub struct ContextArgs {
-    pub trap_rsp: *mut u8,
-}
-
 /// Extended [Base] for x86-64.
 #[repr(C)]
 pub(super) struct Context {
@@ -28,10 +23,10 @@ pub(super) struct Context {
 }
 
 impl Context {
-    pub fn new(base: Base, args: ContextArgs) -> Self {
+    pub fn new(base: Base, arch: &ArchConfig) -> Self {
         Self {
             base,
-            trap_rsp: args.trap_rsp,
+            trap_rsp: arch.trap_rsp as *mut u8,
             user_rsp: 0,
             phantom: PhantomPinned,
         }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
 
     // Setup the CPU after the first print to let the bootloader developer know (some of) their code
     // are working.
-    let cx = unsafe { self::arch::setup_main_cpu() };
+    let arch = unsafe { self::arch::setup_main_cpu() };
 
     // Setup proc0 to represent the kernel.
     let proc0 = Proc::new_bare(Arc::new(Proc0Abi));
@@ -54,7 +54,7 @@ fn main() -> ! {
     // Activate CPU context.
     let thread0 = Arc::new(thread0);
 
-    unsafe { self::context::run_with_context(0, thread0, cx, setup, run) };
+    unsafe { self::context::run_with_context(arch, 0, thread0, setup, run) };
 }
 
 fn setup() -> ContextSetup {


### PR DESCRIPTION
Reversing around this area does not fun due to a lot of logic does not make sense. The good news is we probably don't need some parts of this since we can start the other vCPU in long mode directly.