### PR TITLE
Fixes x11 improper error handling and scaling issues.

### DIFF
--- a/gui/src/ui/backend/mod.rs
+++ b/gui/src/ui/backend/mod.rs
@@ -247,8 +247,8 @@ pub enum BackendError {
     DispatchWayland(#[source] wayland_client::DispatchError),
 
     #[cfg(target_os = "linux")]
-    #[error("couldn't intern X11 atoms: {0}")]
-    XlibInternAtomsFailed(NonZero<i32>),
+    #[error("couldn't intern X11 atoms")]
+    XlibInternAtomsFailed,
 
     #[cfg(target_os = "linux")]
     #[error("couldn't dispatch X11 request")]

--- a/gui/src/ui/backend/window.rs
+++ b/gui/src/ui/backend/window.rs
@@ -2,7 +2,7 @@ use i_slint_core::InternalToken;
 use i_slint_core::window::WindowAdapterInternal;
 use i_slint_renderer_skia::SkiaRenderer;
 use raw_window_handle::{
-    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, WindowHandle,
+    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, WindowHandle,
 };
 use slint::platform::{
     Key, PointerEventButton, Renderer, WindowAdapter, WindowEvent, WindowProperties,
@@ -310,11 +310,15 @@ impl WindowAdapter for SlintWindow {
 
             self.winit.set_visible(true);
 
+            let is_wayland = match self.winit.display_handle().unwrap().as_raw() {
+                RawDisplayHandle::Wayland(_) => true,
+                _ => false,
+            };
+
             // Render initial frame on macOS. Without this the modal will show a blank window until
             // show animation is complete. On Wayland there are some problems when another window is
             // showing so we need to to disable it.
-            #[cfg(target_os = "macos")]
-            {
+            if !is_wayland || cfg!(target_os = "macos") {
                 let scale_factor = self.winit.scale_factor() as f32;
                 let size = self.winit.inner_size();
                 let size = PhysicalSize::new(size.width, size.height);

--- a/gui/src/ui/backend/window.rs
+++ b/gui/src/ui/backend/window.rs
@@ -318,6 +318,7 @@ impl WindowAdapter for SlintWindow {
             // Render initial frame on macOS. Without this the modal will show a blank window until
             // show animation is complete. On Wayland there are some problems when another window is
             // showing so we need to to disable it.
+            // On X11, this fixes the scaling.
             if !is_wayland || cfg!(target_os = "macos") {
                 let scale_factor = self.winit.scale_factor() as f32;
                 let size = self.winit.inner_size();

--- a/gui/src/ui/backend/x11.rs
+++ b/gui/src/ui/backend/x11.rs
@@ -1,6 +1,5 @@
 use super::BackendError;
 use raw_window_handle::{XcbDisplayHandle, XlibDisplayHandle};
-use std::num::NonZero;
 use std::ptr::NonNull;
 use xcb::x::InternAtom;
 
@@ -38,11 +37,10 @@ impl Xlib {
             )
         };
 
-        if let Some(err) = NonZero::new(ret) {
-            return Err(BackendError::XlibInternAtomsFailed(err));
+        match ret {
+            0 => Err(BackendError::XlibInternAtomsFailed),
+            _ => Ok(Self { display, atoms }),
         }
-
-        Ok(Self { display, atoms })
     }
 
     pub fn display(&self) -> NonNull<x11::xlib::Display> {

--- a/gui/src/ui/linux/mod.rs
+++ b/gui/src/ui/linux/mod.rs
@@ -3,8 +3,6 @@ pub use self::dialogs::*;
 use self::modal::Modal;
 use super::backend::ProtocolSpecific;
 use super::{DesktopExt, DesktopWindow, SlintBackend};
-use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-use std::num::NonZero;
 use thiserror::Error;
 
 mod dialogs;

--- a/gui/src/ui/linux/mod.rs
+++ b/gui/src/ui/linux/mod.rs
@@ -79,15 +79,6 @@ pub enum PlatformError {
     #[error("couldn't center window")]
     XcbCenterWindow(#[source] xcb::ProtocolError),
 
-    #[error("couldn't set window type: {0}")]
-    XlibSetWindowType(NonZero<i32>),
-
-    #[error("couldn't set window wm state: {0}")]
-    XlibSetWmState(NonZero<i32>),
-
     #[error("couldn't get window attributes")]
     XlibGetWindowAttributes,
-
-    #[error("couldn't center window: {0}")]
-    XlibCenterWindow(NonZero<i32>),
 }

--- a/gui/src/ui/linux/mod.rs
+++ b/gui/src/ui/linux/mod.rs
@@ -85,8 +85,8 @@ pub enum PlatformError {
     #[error("couldn't set window wm state: {0}")]
     XlibSetWmState(NonZero<i32>),
 
-    #[error("couldn't get window attributes: {0}")]
-    XlibGetWindowAttributes(NonZero<i32>),
+    #[error("couldn't get window attributes")]
+    XlibGetWindowAttributes,
 
     #[error("couldn't center window: {0}")]
     XlibCenterWindow(NonZero<i32>),


### PR DESCRIPTION
I tested it and it turns out that the crate with the bindings generates an int return type even for function that should return void. Also, nonzero values are success and zero values are failure, apparently.