### PR TITLE
Implements DMEM physical memory reservation

### DIFF
--- a/kernel/src/dmem/mod.rs
+++ b/kernel/src/dmem/mod.rs
@@ -11,7 +11,65 @@ impl Dmem {
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x3F5C20|
-    pub fn new(_: &mut MemoryInfo) -> Arc<Self> {
+    pub fn new(mi: &mut MemoryInfo) -> Arc<Self> {
+        // TODO: Figure out what the purpose of this 16MB block of memory.
+        if Self::reserve_phys(mi, 0x1000000, 1) == 0 {
+            panic!("no available memory for high-address memory");
+        }
+
         todo!()
+    }
+
+    /// # Reference offsets
+    /// | Version | Offset |
+    /// |---------|--------|
+    /// |PS4 11.00|0x3F64C0|
+    fn reserve_phys(mi: &mut MemoryInfo, size: u64, align: i64) -> u64 {
+        let mut i = mi.physmap_last;
+
+        loop {
+            let start = mi.physmap[i];
+            let end = mi.physmap[i + 1];
+            let addr = (end - size) & ((-align) as u64);
+
+            if addr >= start {
+                let aligned_end = addr + size;
+
+                // Check if this take the whole block.
+                if (addr == start) && (aligned_end == end) {
+                    mi.physmap.copy_within((i + 2).., i);
+                    mi.physmap_last -= 2;
+                    return addr;
+                }
+
+                // Check if this create a hole in the block.
+                if (addr != start) && (aligned_end != end) {
+                    mi.physmap.copy_within(i..(mi.physmap_last + 2), i + 2);
+                    mi.physmap[i + 1] = addr;
+                    mi.physmap[i + 2] = aligned_end;
+                    mi.physmap_last += 2;
+                    return addr;
+                }
+
+                // Check if this take the end of the block.
+                if addr != start {
+                    assert_eq!(aligned_end, end);
+                    mi.physmap[i + 1] = addr;
+                    return addr;
+                }
+
+                // Take the start of the block.
+                mi.physmap[i] = aligned_end;
+
+                return addr;
+            }
+
+            // Move to lower map.
+            if i < 2 {
+                break 0;
+            }
+
+            i -= 2;
+        }
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -230,7 +230,10 @@ fn load_memory_map() -> MemoryInfo {
     // TODO: There is some unknown calls here.
     load_pmap();
 
+    // The call to initialize_dmem is moved to the caller of this function.
     MemoryInfo {
+        physmap,
+        physmap_last: last,
         boot_area,
         boot_info,
         initial_memory_size,
@@ -366,6 +369,8 @@ impl ProcAbi for Proc0Abi {
 
 /// Contains memory information populated from memory map.
 struct MemoryInfo {
+    physmap: [u64; 60],
+    physmap_last: usize,
     boot_area: u64,
     boot_info: BootInfo,
     initial_memory_size: u64,


### PR DESCRIPTION
Now I know the purpose of DMEM feature on the PS4. All DMEM memory is a reserved memory with fixed size that prevent standard memory management from interfere it. It was designed to prevent out of memory during the game is running.