### PR TITLE
Passes virtual size of the kernel instead of end address

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -17,10 +17,10 @@ pub struct KernelMap {
     ///
     /// This must be the address of ELF header of the kernel.
     pub kern_vaddr: usize,
-    /// The beginning of free virtual address.
+    /// Size of virtual address the kernel is mapped.
     ///
-    /// All address after this must not contains any data.
-    pub free_vaddr: NonZero<usize>,
+    /// This include everything that need to be lived forever (e.g. stack for main CPU).
+    pub kern_vsize: NonZero<usize>,
 }
 
 /// Contains information about the boot environment.

--- a/gui/src/vmm/mod.rs
+++ b/gui/src/vmm/mod.rs
@@ -436,7 +436,7 @@ impl Vmm<()> {
                 0,
                 KernelMap {
                     kern_vaddr,
-                    free_vaddr: vaddr.try_into().unwrap()
+                    kern_vsize: (vaddr - kern_vaddr).try_into().unwrap(),
                 }
             )
             .unwrap()


### PR DESCRIPTION
So it matched with the PS4. On FreeBSD it is named as `physfree`, which effectively the size of mapped kernel since it is mapped at the beginning of the memory.