### PR TITLE
Emulates 16K page size on x86

### DIFF
--- a/kernel/src/config/aarch64.rs
+++ b/kernel/src/config/aarch64.rs
@@ -1,1 +1,0 @@
-pub const PAGE_SHIFT: usize = 14; // 16K

--- a/kernel/src/config/mod.rs
+++ b/kernel/src/config/mod.rs
@@ -1,4 +1,3 @@
-pub use self::arch::*;
 pub use self::dipsw::*;
 
 use alloc::boxed::Box;
@@ -9,11 +8,9 @@ use core::num::NonZero;
 use krt::warn;
 use macros::elf_note;
 
-#[cfg_attr(target_arch = "aarch64", path = "aarch64.rs")]
-#[cfg_attr(target_arch = "x86_64", path = "x86_64.rs")]
-mod arch;
 mod dipsw;
 
+pub const PAGE_SHIFT: usize = 14; // 16K
 pub const PAGE_SIZE: NonZero<usize> = NonZero::new(1 << PAGE_SHIFT).unwrap();
 pub const PAGE_MASK: NonZero<usize> = NonZero::new(PAGE_SIZE.get() - 1).unwrap();
 

--- a/kernel/src/config/x86_64.rs
+++ b/kernel/src/config/x86_64.rs
@@ -1,5 +1,0 @@
-// We use 4K 4-Level Paging here. You may wonder about this because it seems like page size on the
-// PS4 is 16K. The truth is the PS4 emulate the 16K page size with 4K pages. You can check this by
-// yourself by looking at acpi_install_wakeup_handler() function on the PS4 kernel and compare it
-// with FreeBSD version. No idea why the PS4 choose to emulate 16K page.
-pub const PAGE_SHIFT: usize = 12;

--- a/lib/hv/src/ram/builder.rs
+++ b/lib/hv/src/ram/builder.rs
@@ -107,6 +107,8 @@ impl<'a, H: Hypervisor> RamBuilder<'a, H> {
             0x1000 => self.build_4k_page_tables(devices),
             #[cfg(target_arch = "aarch64")]
             0x4000 => self.build_16k_page_tables(devices),
+            #[cfg(target_arch = "x86_64")]
+            0x4000 => self.build_4k_page_tables(devices),
             _ => todo!(),
         }
     }


### PR DESCRIPTION
So we don't need to guess when we see `0x4000` is a page size or something else.