### PR TITLE
Maps physical memory immediately after CPU setup is completed

### DIFF
--- a/kernel/src/aarch64.rs
+++ b/kernel/src/aarch64.rs
@@ -1,11 +1,17 @@
+use crate::config::Config;
 use alloc::string::String;
 use alloc::sync::Arc;
+use config::KernelMap;
 
 pub fn identify_cpu() -> CpuInfo {
     todo!()
 }
 
-pub unsafe fn setup_main_cpu(cpu: CpuInfo) -> Arc<ArchConfig> {
+pub unsafe fn setup_main_cpu(
+    config: &Config,
+    cpu: CpuInfo,
+    map: &'static KernelMap,
+) -> Arc<ArchConfig> {
     todo!()
 }
 


### PR DESCRIPTION
The mechanism FreeBSD and Orbis used to access physical memory in the kernel is simpler than I expected. What it did is reserve a range of virtual address to do a direct map with physical memory. Whenever the kernel need to access physical memory all it does is just add the physical address to the start address of virtual mapping like the following code:

```c
(dmap_pdt << 30 | dmap_pdpt << 39 | 0xffff800000000000) + KPML4phys
```