### PR TITLE
Moves dispatch_gdb from MainProgram to Context

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -606,40 +606,6 @@ impl MainProgram {
 
         Ok(Some(client))
     }
-
-    async fn dispatch_gdb<H: Hypervisor>(
-        cx: &mut Context<H>,
-        res: Result<usize, std::io::Error>,
-        gdb: &mut GdbSession,
-        buf: &[u8],
-        con: &mut (dyn AsyncWrite + Unpin),
-    ) -> Result<bool, ProgramError> {
-        // Check status.
-        let len = res.map_err(ProgramError::ReadDebuggerSocket)?;
-
-        if len == 0 {
-            return Ok(false);
-        }
-
-        // Dispatch the requests.
-        let mut dis = gdb.dispatch_client(&buf[..len], cx);
-
-        while let Some(res) = dis
-            .pump()
-            .await
-            .map_err(|e| ProgramError::DispatchDebugger(Box::new(e)))?
-        {
-            let res = res.as_ref();
-
-            if !res.is_empty() {
-                con.write_all(res)
-                    .await
-                    .map_err(ProgramError::WriteDebuggerSocket)?;
-            }
-        }
-
-        Ok(true)
-    }
 }
 
 impl App for MainProgram {
@@ -835,7 +801,7 @@ impl App for MainProgram {
             // Wait for event.
             let r = select_biased! {
                 v = gdb_read.read(&mut gdb_buf).fuse() => {
-                    Self::dispatch_gdb(&mut cx, v, &mut gdb, &gdb_buf, &mut gdb_write).await?
+                    cx.dispatch_gdb(v, &mut gdb, &gdb_buf, &mut gdb_write).await?
                 }
                 v = cx.vmm.recv().fuse() => cx.dispatch_vmm(v.0, v.1).await?,
             };
@@ -924,6 +890,40 @@ impl<H: Hypervisor> Context<H> {
             VmmEvent::RspValue(v) => self.registers.rsp = Some(v),
             VmmEvent::MemoryData(v) => self.memory_data = Some(v),
             VmmEvent::TranslatedAddress(_) => todo!(),
+        }
+
+        Ok(true)
+    }
+
+    async fn dispatch_gdb(
+        &mut self,
+        res: Result<usize, std::io::Error>,
+        gdb: &mut GdbSession,
+        buf: &[u8],
+        con: &mut (dyn AsyncWrite + Unpin),
+    ) -> Result<bool, ProgramError> {
+        // Check status.
+        let len = res.map_err(ProgramError::ReadDebuggerSocket)?;
+
+        if len == 0 {
+            return Ok(false);
+        }
+
+        // Dispatch the requests.
+        let mut dis = gdb.dispatch_client(&buf[..len], self);
+
+        while let Some(res) = dis
+            .pump()
+            .await
+            .map_err(|e| ProgramError::DispatchDebugger(Box::new(e)))?
+        {
+            let res = res.as_ref();
+
+            if !res.is_empty() {
+                con.write_all(res)
+                    .await
+                    .map_err(ProgramError::WriteDebuggerSocket)?;
+            }
         }
 
         Ok(true)

--- a/gui/src/ui/backend/wayland.rs
+++ b/gui/src/ui/backend/wayland.rs
@@ -204,6 +204,7 @@ impl<'a> Future for Run<'a> {
         let mut queue = self.0.queue.borrow_mut();
         let mut state = self.0.state.borrow_mut();
 
+        // https://github.com/rust-lang/rust/issues/156657
         ready!(queue.poll_dispatch_pending(cx, &mut state)).unwrap();
 
         // SAFETY: The Ok from from poll_dispatch_pending is Infallible, which mean it is impossible


### PR DESCRIPTION
We need a dedicated task for GDB connection since it need to wait for a breakpoint event from VMM before it can send response of a 'c' packet. This PR is a prerequisite for that.