### PR TITLE
Removes interior mutability from UmaKeg

### DIFF
--- a/kernel/src/uma/keg.rs
+++ b/kernel/src/uma/keg.rs
@@ -1,7 +1,6 @@
 use super::arch::small_alloc;
 use super::{Alloc, FreeItem, Slab, SlabHdr, Uma, UmaFlags};
 use crate::config::{PAGE_MASK, PAGE_SHIFT, PAGE_SIZE};
-use crate::lock::Mutex;
 use crate::vm::{PageObj, Vm, kaddr_to_phys};
 use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
@@ -9,22 +8,23 @@ use core::alloc::Layout;
 use core::cmp::{max, min};
 use core::num::NonZero;
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicU32, Ordering};
 
 /// Implementation of `uma_keg` structure.
 pub struct UmaKeg<T> {
     vm: Arc<Vm>,
-    size: NonZero<usize>,             // uk_size
-    rsize: usize,                     // uk_rsize
-    pgoff: usize,                     // uk_pgoff
-    ppera: usize,                     // uk_ppera
-    ipers: usize,                     // uk_ipers
-    alloc: fn(&Vm, Alloc) -> *mut u8, // uk_allocf
-    init: Option<fn()>,               // uk_init
-    max_pages: usize,                 // uk_maxpages
-    recurse: AtomicU32,               // uk_recurse
-    flags: UmaFlags,                  // uk_flags
-    state: Mutex<KegState<T>>,
+    size: NonZero<usize>,                      // uk_size
+    rsize: usize,                              // uk_rsize
+    pgoff: usize,                              // uk_pgoff
+    ppera: usize,                              // uk_ppera
+    ipers: usize,                              // uk_ipers
+    alloc: fn(&Vm, Alloc) -> *mut u8,          // uk_allocf
+    init: Option<fn()>,                        // uk_init
+    max_pages: usize,                          // uk_maxpages
+    pages: usize,                              // uk_pages
+    free: usize,                               // uk_free
+    recurse: u32,                              // uk_recurse
+    partial_slabs: VecDeque<NonNull<Slab<T>>>, // uk_part_slab
+    flags: UmaFlags,                           // uk_flags
 }
 
 impl<T: FreeItem> UmaKeg<T> {
@@ -59,7 +59,7 @@ impl<T: FreeItem> UmaKeg<T> {
         flags |= T::flags();
 
         // Get header layout.
-        let hdr = Layout::new::<SlabHdr<T>>();
+        let hdr = Layout::new::<SlabHdr>();
         let (mut hdr, off) = hdr.extend(Layout::new::<T>()).unwrap();
 
         hdr = hdr.pad_to_align();
@@ -181,13 +181,11 @@ impl<T: FreeItem> UmaKeg<T> {
             alloc,
             init,
             max_pages: 0,
-            recurse: AtomicU32::new(0),
+            pages: 0,
+            free: 0,
+            recurse: 0,
+            partial_slabs: VecDeque::new(),
             flags,
-            state: Mutex::new(KegState {
-                pages: 0,
-                free: 0,
-                partial_slabs: VecDeque::new(),
-            }),
         }
     }
 }
@@ -206,7 +204,7 @@ impl<T> UmaKeg<T> {
     }
 
     pub fn recurse(&self) -> u32 {
-        self.recurse.load(Ordering::Relaxed)
+        self.recurse
     }
 
     pub fn flags(&self) -> UmaFlags {
@@ -225,38 +223,37 @@ impl<T> UmaKeg<T> {
 }
 
 impl<T: FreeItem> UmaKeg<T> {
-    /// Unlike Orbis, our slab contains a strong reference to its keg. That mean all allocated slabs
-    /// need to free manually otherwise the keg will be leak.
-    ///
     /// See `keg_fetch_slab` on the Orbis for a reference.
     ///
     /// # Reference offsets
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x141E20|
-    pub fn fetch_slab(self: &Arc<Self>, mut flags: Alloc) -> Option<NonNull<Slab<T>>> {
-        let mut state = self.state.lock();
-
-        while state.free == 0 {
+    pub unsafe fn fetch_slab(&mut self, mut flags: Alloc) -> Option<NonNull<Slab<T>>> {
+        while self.free == 0 {
             if flags.has_any(Alloc::NoVm) {
                 return None;
             }
 
             #[allow(clippy::while_immutable_condition)] // TODO: Remove this.
-            while self.max_pages != 0 && self.max_pages <= state.pages {
+            while self.max_pages != 0 && self.max_pages <= self.pages {
                 todo!()
             }
 
-            self.recurse.fetch_add(1, Ordering::Relaxed);
-            let slab = self.alloc_slab(&mut state, flags);
-            self.recurse.fetch_sub(1, Ordering::Relaxed);
+            self.recurse += 1;
+            let slab = self.alloc_slab(flags);
+            self.recurse -= 1;
 
             if let Some(slab) = NonNull::new(slab) {
-                state.partial_slabs.push_front(slab);
+                self.partial_slabs.push_front(slab);
                 return Some(slab);
             }
 
             flags |= Alloc::NoVm;
+        }
+
+        if let Some(v) = self.partial_slabs.front().copied() {
+            return Some(v);
         }
 
         todo!()
@@ -268,7 +265,7 @@ impl<T: FreeItem> UmaKeg<T> {
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x13FBA0|
-    fn alloc_slab(self: &Arc<Self>, state: &mut KegState<T>, flags: Alloc) -> *mut Slab<T> {
+    fn alloc_slab(&mut self, flags: Alloc) -> *mut Slab<T> {
         if self.flags.has_any(UmaFlags::Offpage) {
             todo!()
         } else {
@@ -285,7 +282,7 @@ impl<T: FreeItem> UmaKeg<T> {
             if !mem.is_null() {
                 // The Orbis also check if uk_flags does not contains UMA_ZONE_OFFPAGE, which seems
                 // to be useless since we only be here when it does not contains UMA_ZONE_OFFPAGE.
-                let hdr = unsafe { mem.byte_add(self.pgoff).cast::<SlabHdr<T>>() };
+                let hdr = unsafe { mem.byte_add(self.pgoff).cast::<SlabHdr>() };
 
                 if self.flags.has_any(UmaFlags::VToSlab) {
                     let mut next = mem as usize;
@@ -311,7 +308,6 @@ impl<T: FreeItem> UmaKeg<T> {
                 // we encounter some memory corruptions then this is likely to be the root of
                 // problem.
                 let v = SlabHdr {
-                    keg: self.clone(),
                     free_count: self.ipers,
                     first_free: 0,
                     items: mem,
@@ -320,9 +316,7 @@ impl<T: FreeItem> UmaKeg<T> {
                 unsafe { hdr.write(v) };
 
                 // Initialize free items. The offset calculation here should be optimized away.
-                let (_, off) = Layout::new::<SlabHdr<T>>()
-                    .extend(Layout::new::<T>())
-                    .unwrap();
+                let (_, off) = Layout::new::<SlabHdr>().extend(Layout::new::<T>()).unwrap();
                 let free = unsafe { hdr.byte_add(off).cast::<T>() };
 
                 for i in 0..self.ipers {
@@ -339,8 +333,8 @@ impl<T: FreeItem> UmaKeg<T> {
                     todo!()
                 }
 
-                state.pages += self.ppera;
-                state.free += self.ipers;
+                self.pages += self.ppera;
+                self.free += self.ipers;
 
                 return core::ptr::slice_from_raw_parts_mut(hdr, self.ipers) as *mut Slab<T>;
             }
@@ -349,12 +343,3 @@ impl<T: FreeItem> UmaKeg<T> {
         }
     }
 }
-
-/// Mutable state of [UmaKeg].
-struct KegState<T> {
-    pages: usize,                              // uk_pages
-    free: usize,                               // uk_free
-    partial_slabs: VecDeque<NonNull<Slab<T>>>, // uk_part_slab
-}
-
-unsafe impl<T: Send> Send for KegState<T> {}

--- a/kernel/src/uma/slab.rs
+++ b/kernel/src/uma/slab.rs
@@ -1,5 +1,4 @@
 use super::{UmaFlags, UmaKeg};
-use alloc::sync::Arc;
 
 /// Implementation of `uma_slab` and `uma_slab_refcnt`.
 ///
@@ -10,22 +9,25 @@ use alloc::sync::Arc;
 /// some places.
 #[repr(C)]
 pub struct Slab<I> {
-    pub hdr: SlabHdr<I>, // us_head
-    pub free: [I],       // us_freelist
+    pub hdr: SlabHdr, // us_head
+    pub free: [I],    // us_freelist
 }
 
 impl<I> Slab<I> {
     /// See `slab_alloc_item` on the Orbis for a reference.
     ///
+    /// # Safety
+    /// This slab must be allocated from `keg`.
+    ///
     /// # Reference offsets
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x141FE0|
-    pub fn alloc_item(&mut self) -> *mut u8 {
+    pub unsafe fn alloc_item(&mut self, keg: &UmaKeg<I>) -> *mut u8 {
         self.hdr.free_count -= 1;
 
         if self.hdr.free_count != 0 {
-            let off = self.hdr.first_free * self.hdr.keg.allocated_size();
+            let off = self.hdr.first_free * keg.allocated_size();
 
             return unsafe { self.hdr.items.add(off) };
         }
@@ -35,11 +37,10 @@ impl<I> Slab<I> {
 }
 
 /// Implementation of `uma_slab_head`.
-pub struct SlabHdr<I> {
-    pub keg: Arc<UmaKeg<I>>, // us_keg
-    pub free_count: usize,   // us_freecount
-    pub first_free: usize,   // us_firstfree
-    pub items: *mut u8,      // us_data
+pub struct SlabHdr {
+    pub free_count: usize, // us_freecount
+    pub first_free: usize, // us_firstfree
+    pub items: *mut u8,    // us_data
 }
 
 /// Item in [Slab::free] to represents `uma_slab` structure.

--- a/kernel/src/uma/zone.rs
+++ b/kernel/src/uma/zone.rs
@@ -21,11 +21,11 @@ pub struct UmaZone<T> {
     bucket_zones: Arc<Vec<UmaZone<StdFree>>>,
     ty: ZoneType,
     size: NonZero<usize>, // uz_size
-    slab: fn(&Self, &mut ZoneState<T>, Option<&Arc<UmaKeg<T>>>, Alloc) -> Option<NonNull<Slab<T>>>, // uz_slab
+    slab: unsafe fn(&mut UmaKeg<T>, Alloc) -> Option<NonNull<Slab<T>>>, // uz_slab
     init: Option<fn(*mut u8, NonZero<usize>, Alloc) -> bool>, // uz_init
     ctor: Option<fn(*mut u8, NonZero<usize>, Alloc) -> bool>, // uz_ctor
-    caches: CpuLocal<RefCell<UmaCache>>,                      // uz_cpu
-    flags: UmaFlags,                                          // uz_flags
+    caches: CpuLocal<RefCell<UmaCache>>, // uz_cpu
+    flags: UmaFlags,      // uz_flags
     state: Mutex<ZoneState<T>>,
 }
 
@@ -126,7 +126,7 @@ impl<T: FreeItem> UmaZone<T> {
             caches: CpuLocal::new(|_| RefCell::default()),
             flags,
             state: Mutex::new(ZoneState {
-                kegs: LinkedList::from([Arc::new(keg)]),
+                kegs: LinkedList::from([keg]),
                 full_buckets: VecDeque::default(),
                 free_buckets: VecDeque::default(),
                 alloc_count: 0,
@@ -304,25 +304,24 @@ impl<T> UmaZone<T> {
 
         if state.fills < config().cpu_count().get().into() {
             let n = min(b.items.len(), state.count);
-            let mut k = None;
+            let k = state.kegs.front_mut().unwrap();
             let mut f = flags;
 
             state.fills += 1;
 
             while b.hdr.len < n {
-                let s = match (self.slab)(self, state, k.as_ref(), f) {
+                let s = match unsafe { (self.slab)(k, f) } {
                     Some(v) => v.as_ptr(),
                     None => todo!(),
                 };
 
                 while unsafe { (*s).hdr.free_count != 0 && b.hdr.len < n } {
-                    let i = unsafe { (*s).alloc_item() };
+                    let i = unsafe { (*s).alloc_item(k) };
 
                     b.items[b.hdr.len] = i;
                     b.hdr.len += 1;
                 }
 
-                k = unsafe { Some((*s).hdr.keg.clone()) };
                 f |= Alloc::NoWait;
             }
 
@@ -354,10 +353,11 @@ impl<T> UmaZone<T> {
     /// |PS4 11.00|0x13DD50|
     fn alloc_item(&self, state: &mut ZoneState<T>, flags: Alloc) -> *mut u8 {
         // Get a slab.
-        let slab = (self.slab)(self, state, None, flags);
+        let keg = state.kegs.front_mut().unwrap();
+        let slab = unsafe { (self.slab)(keg, flags) };
 
         if let Some(mut slab) = slab {
-            let item = unsafe { slab.as_mut().alloc_item() };
+            let item = unsafe { slab.as_mut().alloc_item(keg) };
 
             state.alloc_count += 1;
 
@@ -387,17 +387,10 @@ impl<T: FreeItem> UmaZone<T> {
     /// | Version | Offset |
     /// |---------|--------|
     /// |PS4 11.00|0x141DB0|
-    fn fetch_slab(
-        &self,
-        state: &mut ZoneState<T>,
-        keg: Option<&Arc<UmaKeg<T>>>,
-        flags: Alloc,
-    ) -> Option<NonNull<Slab<T>>> {
-        let keg = keg.unwrap_or(state.kegs.front().unwrap());
-
+    unsafe fn fetch_slab(keg: &mut UmaKeg<T>, flags: Alloc) -> Option<NonNull<Slab<T>>> {
         if !keg.flags().has_any(UmaFlags::Bucket) || keg.recurse() == 0 {
             loop {
-                if let Some(v) = keg.fetch_slab(flags) {
+                if let Some(v) = unsafe { keg.fetch_slab(flags) } {
                     return Some(v);
                 }
 
@@ -413,7 +406,7 @@ impl<T: FreeItem> UmaZone<T> {
 
 /// Contains mutable data for [UmaZone].
 struct ZoneState<T> {
-    kegs: LinkedList<Arc<UmaKeg<T>>>,           // uz_kegs + uz_klink
+    kegs: LinkedList<UmaKeg<T>>,                // uz_kegs + uz_klink
     full_buckets: VecDeque<NonNull<UmaBucket>>, // uz_full_bucket
     free_buckets: VecDeque<NonNull<UmaBucket>>, // uz_free_bucket
     alloc_count: u64,                           // uz_allocs


### PR DESCRIPTION
Now we have reached init process creation:

```
[I]: Starting Obliteration Kernel on KVM (x86_64 7.0.13-arch1-2).
     cpu_vendor                 : AuthenticAMD × 8
     cpu_id                     : 0x740f30
     boot_parameter.idps.product: UC2/USA/CANADA
     physfree                   : 0x21a4000
     kernel/src/main.rs:57
[I]: Memory map loaded with 2 maps.
     initial_memory_size: 8554659840 (8.55 GB)
     basemem            : 0x280
     boot_address       : 0x9c000
     mptramp_pagetables : 0x90000
     Maxmem             : 0x80000
     0x0000000000000000-0x0000000000090000 (589.82 kB)
     0x0000000002244000-0x0000000200000000 (8.55 GB)
     kernel/src/main.rs:120
[I]: DMEM initialized.
     Mode  : 20 (GL8 release)
     Maxmem: 0x80000
     0x0000000000000000-0x0000000000090000 (589.82 kB)
     0x0000000002244000-0x0000000060000000 (1.57 GB)
     0x00000001b8000000-0x00000001fd600000 (1.16 GB)
     0x00000001ff000000-0x0000000200000000 (16.78 MB)
     kernel/src/main.rs:147
[I]: Available physical memory populated.
     Maxmem    : 0x80000
     physmem   : 168210
     phys_avail:
     0x0000000000004000-0x0000000000090000 (573.44 kB)
     0x0000000002244000-0x0000000060000000 (1.57 GB)
     0x00000001b8000000-0x00000001fd600000 (1.16 GB)
     0x00000001ff000000-0x00000001ffff0000 (16.71 MB)
     dump_avail:
     0x0000000000000000-0x0000000000090000 (589.82 kB)
     0x0000000002244000-0x0000000060000000 (1.57 GB)
     0x00000001b8000000-0x00000001fd600000 (1.16 GB)
     0x00000001ff000000-0x0000000200000000 (16.78 MB)
     kernel/src/main.rs:257
[I]: VM stats initialized.
     v_page_count[0]: 102670
     v_free_count[0]: 102670
     v_page_count[1]: 65536
     kernel/src/vm/mod.rs:115
[I]: Activating stage 2 heap.
     kernel/src/main.rs:286
[I]: Creating init process.
     kernel/src/main.rs:514
[E]: Kernel panic - not yet implemented.
     kernel/src/proc/process.rs:42
```