### PR TITLE
Implements identify_cpu() for AArch64

### DIFF
--- a/kernel/src/aarch64.rs
+++ b/kernel/src/aarch64.rs
@@ -1,10 +1,38 @@
 use crate::config::Config;
+use alloc::format;
 use alloc::string::String;
 use alloc::sync::Arc;
 use config::KernelMap;
+use core::arch::asm;
 
 pub fn identify_cpu() -> CpuInfo {
-    todo!()
+    // Load MIDR_EL1.
+    let id: u64;
+
+    unsafe { asm!("mrs {v}, MIDR_EL1", v = out(reg) id, options(pure, nomem, nostack)) };
+
+    // Get vendor.
+    let cpu_vendor = match (id & 0xFF000000) >> 24 {
+        0x41 => "Arm Limited".into(),
+        0x42 => "Broadcom Corporation".into(),
+        0x43 => "Cavium Inc".into(),
+        0x44 => "Digital Equipment Corporation".into(),
+        0x46 => "Fujitsu Ltd".into(),
+        0x49 => "Infineon Technologies AG".into(),
+        0x4D => "Motorola/Freescale Semiconductor Inc".into(),
+        0x4E => "NVIDIA Corporation".into(),
+        0x50 => "Applied Micro Circuits Corporation".into(),
+        0x51 => "Qualcomm Inc".into(),
+        0x56 => "Marvell International Ltd".into(),
+        0x69 => "Intel Corporation".into(),
+        0xC0 => "Ampere Computing".into(),
+        v => format!("Unknown {v:#x}"),
+    };
+
+    CpuInfo {
+        cpu_vendor,
+        cpu_id: (id & 0xFFFFFFFF) as u32,
+    }
 }
 
 pub unsafe fn setup_main_cpu(
@@ -18,7 +46,7 @@ pub unsafe fn setup_main_cpu(
 /// Contains information for CPU on current machine.
 pub struct CpuInfo {
     pub cpu_vendor: String,
-    pub cpu_id: u32, // TODO: Figure out how to remove this.
+    pub cpu_id: u32,
 }
 
 /// Contains architecture-specific configurations obtained from [`setup_main_cpu()`].

--- a/macros/src/elf.rs
+++ b/macros/src/elf.rs
@@ -101,7 +101,7 @@ pub fn transform_note(opts: Options, mut item: ItemStatic) -> syn::Result<TokenS
     // Compose.
     Ok(quote! {
         #[used]
-        #[cfg_attr(not(test), unsafe(link_section = #section))]
+        #[cfg_attr(target_os = "none", unsafe(link_section = #section))]
         #item
     })
 }


### PR DESCRIPTION
```
[I]: Starting Obliteration Kernel on Hypervisor Framework (arm64 25.5.0).
     cpu_vendor                 : Unknown 0x61 × 8
     cpu_id                     : 0x610f0000
     boot_parameter.idps.product: UC2/USA/CANADA
     physfree                   : 0x21e0000
     kernel/src/main.rs:57
[E]: Kernel panic - not yet implemented.
     kernel/src/aarch64.rs:43
```