### PR TITLE
Adds Apple as a known CPU vendor

### DIFF
--- a/kernel/src/aarch64.rs
+++ b/kernel/src/aarch64.rs
@@ -24,6 +24,7 @@ pub fn identify_cpu() -> CpuInfo {
         0x50 => "Applied Micro Circuits Corporation".into(),
         0x51 => "Qualcomm Inc".into(),
         0x56 => "Marvell International Ltd".into(),
+        0x61 => "Apple Inc".into(),
         0x69 => "Intel Corporation".into(),
         0xC0 => "Ampere Computing".into(),
         v => format!("Unknown {v:#x}"),


### PR DESCRIPTION
From MacBook Air Apple M4

```
[I]: Starting Obliteration Kernel on Hypervisor Framework (arm64 25.5.0).
     cpu_vendor                 : Unknown 0x61 × 8
     cpu_id                     : 0x610f0000
     boot_parameter.idps.product: UC2/USA/CANADA
     physfree                   : 0x21e0000
     kernel/src/main.rs:57
[E]: Kernel panic - not yet implemented.
     kernel/src/aarch64.rs:43
```
